### PR TITLE
Improve handling of shared materials between LODs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The current release includes code for:
 ## Dependencies
 
 This project consumes the following projects through NuGet packages:
-- [Microsoft.glTF.CPP](https://www.nuget.org/packages/Microsoft.glTF.CPP/1.3.25), licensed under the MIT license
+- [Microsoft.glTF.CPP](https://www.nuget.org/packages/Microsoft.glTF.CPP), licensed under the MIT license
 - [DirectXTex](http://github.com/Microsoft/DirectXTex), licensed under the MIT license
 - [RapidJSON](https://github.com/Tencent/rapidjson/), licensed under the MIT license
 

--- a/WindowsMRAssetConverter/CommandLine.cpp
+++ b/WindowsMRAssetConverter/CommandLine.cpp
@@ -25,8 +25,7 @@ enum class CommandLineParsingState
     ReadTmpDir,
     ReadLods,
     ReadScreenCoverage,
-    ReadMaxTextureSize,
-    ShareMaterials
+    ReadMaxTextureSize
 };
 
 void CommandLine::PrintHelp()

--- a/WindowsMRAssetConverter/CommandLine.cpp
+++ b/WindowsMRAssetConverter/CommandLine.cpp
@@ -66,7 +66,7 @@ void CommandLine::ParseCommandLineArguments(
     int argc, wchar_t *argv[],
     std::wstring& inputFilePath, AssetType& inputAssetType, std::wstring& outFilePath, std::wstring& tempDirectory,
     std::vector<std::wstring>& lodFilePaths, std::vector<double>& screenCoveragePercentages, size_t& maxTextureSize,
-    bool& share_materials)
+    bool& shareMaterials)
 {
     CommandLineParsingState state = CommandLineParsingState::Initial;
 
@@ -80,7 +80,7 @@ void CommandLine::ParseCommandLineArguments(
     lodFilePaths.clear();
     screenCoveragePercentages.clear();
     maxTextureSize = MAXTEXTURESIZE_DEFAULT;
-    share_materials = false;
+    shareMaterials = false;
 
     state = CommandLineParsingState::InputRead;
 
@@ -117,7 +117,7 @@ void CommandLine::ParseCommandLineArguments(
         }
         else if (param == PARAM_SHARE_MATERIALS)
         {
-            share_materials = true;
+            shareMaterials = true;
         }
         else
         {

--- a/WindowsMRAssetConverter/CommandLine.cpp
+++ b/WindowsMRAssetConverter/CommandLine.cpp
@@ -11,6 +11,7 @@ const wchar_t * PARAM_TMPDIR = L"-temp-directory";
 const wchar_t * PARAM_LOD = L"-lod";
 const wchar_t * PARAM_SCREENCOVERAGE = L"-screen-coverage";
 const wchar_t * PARAM_MAXTEXTURESIZE = L"-max-texture-size";
+const wchar_t * PARAM_SHARE_MATERIALS = L"-share-materials";
 const wchar_t * SUFFIX_CONVERTED = L"_converted";
 const wchar_t * CLI_INDENT = L"    ";
 const size_t MAXTEXTURESIZE_DEFAULT = 512;
@@ -24,7 +25,8 @@ enum class CommandLineParsingState
     ReadTmpDir,
     ReadLods,
     ReadScreenCoverage,
-    ReadMaxTextureSize
+    ReadMaxTextureSize,
+    ShareMaterials
 };
 
 void CommandLine::PrintHelp()
@@ -44,6 +46,7 @@ void CommandLine::PrintHelp()
         << indent << "[" << std::wstring(PARAM_LOD) << " <path to each lower LOD asset in descending order of quality>]" << std::endl
         << indent << "[" << std::wstring(PARAM_SCREENCOVERAGE) << " <LOD screen coverage values>]" << std::endl
         << indent << "[" << std::wstring(PARAM_MAXTEXTURESIZE) << " <Max texture size in pixels, defaults to 512>]" << std::endl
+        << indent << "[" << std::wstring(PARAM_SHARE_MATERIALS) << " defaults to false" << std::endl
         << std::endl
         << "Example:" << std::endl
         << indent << "WindowsMRAssetConverter FileToConvert.gltf "
@@ -62,7 +65,8 @@ void CommandLine::PrintHelp()
 void CommandLine::ParseCommandLineArguments(
     int argc, wchar_t *argv[],
     std::wstring& inputFilePath, AssetType& inputAssetType, std::wstring& outFilePath, std::wstring& tempDirectory,
-    std::vector<std::wstring>& lodFilePaths, std::vector<double>& screenCoveragePercentages, size_t& maxTextureSize)
+    std::vector<std::wstring>& lodFilePaths, std::vector<double>& screenCoveragePercentages, size_t& maxTextureSize,
+    bool& share_materials)
 {
     CommandLineParsingState state = CommandLineParsingState::Initial;
 
@@ -76,6 +80,7 @@ void CommandLine::ParseCommandLineArguments(
     lodFilePaths.clear();
     screenCoveragePercentages.clear();
     maxTextureSize = MAXTEXTURESIZE_DEFAULT;
+    share_materials = false;
 
     state = CommandLineParsingState::InputRead;
 
@@ -109,6 +114,10 @@ void CommandLine::ParseCommandLineArguments(
         {
             maxTextureSize = MAXTEXTURESIZE_DEFAULT;
             state = CommandLineParsingState::ReadMaxTextureSize;
+        }
+        else if (param == PARAM_SHARE_MATERIALS)
+        {
+            share_materials = true;
         }
         else
         {

--- a/WindowsMRAssetConverter/CommandLine.h
+++ b/WindowsMRAssetConverter/CommandLine.h
@@ -13,6 +13,7 @@ namespace CommandLine
     void ParseCommandLineArguments(
         int argc, wchar_t *argv[],
         std::wstring& inputFilePath, AssetType& inputAssetType, std::wstring& outFilePath, std::wstring& tempDirectory,
-        std::vector<std::wstring>& lodFilePaths, std::vector<double>& screenCoveragePercentages, size_t& maxTextureSize);
+        std::vector<std::wstring>& lodFilePaths, std::vector<double>& screenCoveragePercentages, size_t& maxTextureSize,
+        bool& shared_materials);
 };
 

--- a/WindowsMRAssetConverter/CommandLine.h
+++ b/WindowsMRAssetConverter/CommandLine.h
@@ -14,6 +14,6 @@ namespace CommandLine
         int argc, wchar_t *argv[],
         std::wstring& inputFilePath, AssetType& inputAssetType, std::wstring& outFilePath, std::wstring& tempDirectory,
         std::vector<std::wstring>& lodFilePaths, std::vector<double>& screenCoveragePercentages, size_t& maxTextureSize,
-        bool& shared_materials);
+        bool& sharedMaterials);
 };
 

--- a/WindowsMRAssetConverter/WindowsMRAssetConverter.cpp
+++ b/WindowsMRAssetConverter/WindowsMRAssetConverter.cpp
@@ -74,7 +74,7 @@ GLTFDocument LoadAndConvertDocumentForWindowsMR(
     AssetType inputAssetType,
     const std::wstring& tempDirectory,
     size_t maxTextureSize,
-    bool packTextures)
+    bool processTextures = true)
 {
     // Load the document
     std::experimental::filesystem::path inputFilePathFS(inputFilePath);
@@ -104,7 +104,7 @@ GLTFDocument LoadAndConvertDocumentForWindowsMR(
 
     GLTFStreamReader streamReader(FileSystem::GetBasePath(inputFilePath));
 
-    if (packTextures)
+    if (processTextures)
     {
         std::wcout << L"Packing textures..." << std::endl;
 
@@ -142,14 +142,14 @@ int wmain(int argc, wchar_t *argv[])
         std::vector<std::wstring> lodFilePaths;
         std::vector<double> screenCoveragePercentages;
         size_t maxTextureSize;
-        bool share_materials;
+        bool shareMaterials;
 
-        CommandLine::ParseCommandLineArguments(argc, argv, inputFilePath, inputAssetType, outFilePath, tempDirectory, lodFilePaths, screenCoveragePercentages, maxTextureSize, share_materials);
+        CommandLine::ParseCommandLineArguments(argc, argv, inputFilePath, inputAssetType, outFilePath, tempDirectory, lodFilePaths, screenCoveragePercentages, maxTextureSize, shareMaterials);
 
         // Load document, and perform steps:
         // 1. Texture Packing
         // 2. Texture Compression
-        auto document = LoadAndConvertDocumentForWindowsMR(inputFilePath, inputAssetType, tempDirectory, maxTextureSize, true);
+        auto document = LoadAndConvertDocumentForWindowsMR(inputFilePath, inputAssetType, tempDirectory, maxTextureSize);
 
         // 3. LOD Merging
         if (lodFilePaths.size() > 0)
@@ -166,12 +166,12 @@ int wmain(int argc, wchar_t *argv[])
                 auto lod = lodFilePaths[i];
                 auto subFolder = FileSystem::CreateSubFolder(tempDirectory, L"lod" + std::to_wstring(i + 1));
 
-                lodDocuments.push_back(LoadAndConvertDocumentForWindowsMR(lod, AssetTypeUtils::AssetTypeFromFilePath(lod), subFolder, maxTextureSize, !share_materials));
+                lodDocuments.push_back(LoadAndConvertDocumentForWindowsMR(lod, AssetTypeUtils::AssetTypeFromFilePath(lod), subFolder, maxTextureSize, !shareMaterials));
             
                 lodDocumentRelativePaths.push_back(FileSystem::GetRelativePathWithTrailingSeparator(FileSystem::GetBasePath(inputFilePath), FileSystem::GetBasePath(lod)));
             }
 
-            document = GLTFLODUtils::MergeDocumentsAsLODs(lodDocuments, screenCoveragePercentages, lodDocumentRelativePaths, share_materials);
+            document = GLTFLODUtils::MergeDocumentsAsLODs(lodDocuments, screenCoveragePercentages, lodDocumentRelativePaths, shareMaterials);
         }
 
         // 4. Make sure there's a default scene

--- a/WindowsMRAssetConverter/WindowsMRAssetConverter.vcxproj
+++ b/WindowsMRAssetConverter/WindowsMRAssetConverter.vcxproj
@@ -206,15 +206,15 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\rapidjson.temprelease.0.0.2.20\build\native\rapidjson.temprelease.targets" Condition="Exists('..\packages\rapidjson.temprelease.0.0.2.20\build\native\rapidjson.temprelease.targets')" />
-    <Import Project="..\packages\directxtex_desktop_2015.2017.12.13.1\build\native\directxtex_desktop_2015.targets" Condition="Exists('..\packages\directxtex_desktop_2015.2017.12.13.1\build\native\directxtex_desktop_2015.targets')" />
-    <Import Project="..\packages\Microsoft.glTF.CPP.1.3.26.0\build\native\Microsoft.glTF.CPP.targets" Condition="Exists('..\packages\Microsoft.glTF.CPP.1.3.26.0\build\native\Microsoft.glTF.CPP.targets')" />
+    <Import Project="..\packages\directxtex_desktop_2015.2018.2.9.1\build\native\directxtex_desktop_2015.targets" Condition="Exists('..\packages\directxtex_desktop_2015.2018.2.9.1\build\native\directxtex_desktop_2015.targets')" />
+    <Import Project="..\packages\Microsoft.glTF.CPP.1.3.46.0\build\native\Microsoft.glTF.CPP.targets" Condition="Exists('..\packages\Microsoft.glTF.CPP.1.3.46.0\build\native\Microsoft.glTF.CPP.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\rapidjson.temprelease.0.0.2.20\build\native\rapidjson.temprelease.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\rapidjson.temprelease.0.0.2.20\build\native\rapidjson.temprelease.targets'))" />
-    <Error Condition="!Exists('..\packages\directxtex_desktop_2015.2017.12.13.1\build\native\directxtex_desktop_2015.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\directxtex_desktop_2015.2017.12.13.1\build\native\directxtex_desktop_2015.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.glTF.CPP.1.3.26.0\build\native\Microsoft.glTF.CPP.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.glTF.CPP.1.3.26.0\build\native\Microsoft.glTF.CPP.targets'))" />
+    <Error Condition="!Exists('..\packages\directxtex_desktop_2015.2018.2.9.1\build\native\directxtex_desktop_2015.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\directxtex_desktop_2015.2018.2.9.1\build\native\directxtex_desktop_2015.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.glTF.CPP.1.3.46.0\build\native\Microsoft.glTF.CPP.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.glTF.CPP.1.3.46.0\build\native\Microsoft.glTF.CPP.targets'))" />
   </Target>
 </Project>

--- a/WindowsMRAssetConverter/packages.config
+++ b/WindowsMRAssetConverter/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="directxtex_desktop_2015" version="2017.12.13.1" targetFramework="native" />
-  <package id="Microsoft.glTF.CPP" version="1.3.26.0" targetFramework="native" />
+  <package id="directxtex_desktop_2015" version="2018.2.9.1" targetFramework="native" />
+  <package id="Microsoft.glTF.CPP" version="1.3.46.0" targetFramework="native" />
   <package id="rapidjson.temprelease" version="0.0.2.20" targetFramework="native" />
 </packages>

--- a/glTF-Toolkit.Test/glTF-Toolkit.Test.vcxproj
+++ b/glTF-Toolkit.Test/glTF-Toolkit.Test.vcxproj
@@ -237,15 +237,15 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\rapidjson.temprelease.0.0.2.20\build\native\rapidjson.temprelease.targets" Condition="Exists('..\packages\rapidjson.temprelease.0.0.2.20\build\native\rapidjson.temprelease.targets')" />
-    <Import Project="..\packages\directxtex_desktop_2015.2017.12.13.1\build\native\directxtex_desktop_2015.targets" Condition="Exists('..\packages\directxtex_desktop_2015.2017.12.13.1\build\native\directxtex_desktop_2015.targets')" />
-    <Import Project="..\packages\Microsoft.glTF.CPP.1.3.26.0\build\native\Microsoft.glTF.CPP.targets" Condition="Exists('..\packages\Microsoft.glTF.CPP.1.3.26.0\build\native\Microsoft.glTF.CPP.targets')" />
+    <Import Project="..\packages\directxtex_desktop_2015.2018.2.9.1\build\native\directxtex_desktop_2015.targets" Condition="Exists('..\packages\directxtex_desktop_2015.2018.2.9.1\build\native\directxtex_desktop_2015.targets')" />
+    <Import Project="..\packages\Microsoft.glTF.CPP.1.3.46.0\build\native\Microsoft.glTF.CPP.targets" Condition="Exists('..\packages\Microsoft.glTF.CPP.1.3.46.0\build\native\Microsoft.glTF.CPP.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\rapidjson.temprelease.0.0.2.20\build\native\rapidjson.temprelease.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\rapidjson.temprelease.0.0.2.20\build\native\rapidjson.temprelease.targets'))" />
-    <Error Condition="!Exists('..\packages\directxtex_desktop_2015.2017.12.13.1\build\native\directxtex_desktop_2015.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\directxtex_desktop_2015.2017.12.13.1\build\native\directxtex_desktop_2015.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.glTF.CPP.1.3.26.0\build\native\Microsoft.glTF.CPP.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.glTF.CPP.1.3.26.0\build\native\Microsoft.glTF.CPP.targets'))" />
+    <Error Condition="!Exists('..\packages\directxtex_desktop_2015.2018.2.9.1\build\native\directxtex_desktop_2015.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\directxtex_desktop_2015.2018.2.9.1\build\native\directxtex_desktop_2015.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.glTF.CPP.1.3.46.0\build\native\Microsoft.glTF.CPP.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.glTF.CPP.1.3.46.0\build\native\Microsoft.glTF.CPP.targets'))" />
   </Target>
 </Project>

--- a/glTF-Toolkit.Test/packages.config
+++ b/glTF-Toolkit.Test/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="directxtex_desktop_2015" version="2017.12.13.1" targetFramework="native" />
-  <package id="Microsoft.glTF.CPP" version="1.3.26.0" targetFramework="native" />
+  <package id="directxtex_desktop_2015" version="2018.2.9.1" targetFramework="native" />
+  <package id="Microsoft.glTF.CPP" version="1.3.46.0" targetFramework="native" />
   <package id="rapidjson.temprelease" version="0.0.2.20" targetFramework="native" />
 </packages>

--- a/glTF-Toolkit.UWP.Test/glTF-Toolkit.UWP.Test.csproj
+++ b/glTF-Toolkit.UWP.Test/glTF-Toolkit.UWP.Test.csproj
@@ -131,7 +131,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.0.5</Version>
+      <Version>6.0.7</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestAdapter">
       <Version>1.2.0</Version>

--- a/glTF-Toolkit.UWP/glTF-Toolkit.UWP.vcxproj
+++ b/glTF-Toolkit.UWP/glTF-Toolkit.UWP.vcxproj
@@ -284,15 +284,15 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\rapidjson.temprelease.0.0.2.20\build\native\rapidjson.temprelease.targets" Condition="Exists('..\packages\rapidjson.temprelease.0.0.2.20\build\native\rapidjson.temprelease.targets')" />
-    <Import Project="..\packages\directxtex_uwp.2017.12.13.1\build\native\directxtex_uwp.targets" Condition="Exists('..\packages\directxtex_uwp.2017.12.13.1\build\native\directxtex_uwp.targets')" />
-    <Import Project="..\packages\Microsoft.glTF.CPP.1.3.26.0\build\native\Microsoft.glTF.CPP.targets" Condition="Exists('..\packages\Microsoft.glTF.CPP.1.3.26.0\build\native\Microsoft.glTF.CPP.targets')" />
+    <Import Project="..\packages\directxtex_uwp.2018.2.9.1\build\native\directxtex_uwp.targets" Condition="Exists('..\packages\directxtex_uwp.2018.2.9.1\build\native\directxtex_uwp.targets')" />
+    <Import Project="..\packages\Microsoft.glTF.CPP.1.3.46.0\build\native\Microsoft.glTF.CPP.targets" Condition="Exists('..\packages\Microsoft.glTF.CPP.1.3.46.0\build\native\Microsoft.glTF.CPP.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\rapidjson.temprelease.0.0.2.20\build\native\rapidjson.temprelease.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\rapidjson.temprelease.0.0.2.20\build\native\rapidjson.temprelease.targets'))" />
-    <Error Condition="!Exists('..\packages\directxtex_uwp.2017.12.13.1\build\native\directxtex_uwp.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\directxtex_uwp.2017.12.13.1\build\native\directxtex_uwp.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.glTF.CPP.1.3.26.0\build\native\Microsoft.glTF.CPP.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.glTF.CPP.1.3.26.0\build\native\Microsoft.glTF.CPP.targets'))" />
+    <Error Condition="!Exists('..\packages\directxtex_uwp.2018.2.9.1\build\native\directxtex_uwp.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\directxtex_uwp.2018.2.9.1\build\native\directxtex_uwp.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.glTF.CPP.1.3.46.0\build\native\Microsoft.glTF.CPP.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.glTF.CPP.1.3.46.0\build\native\Microsoft.glTF.CPP.targets'))" />
   </Target>
 </Project>

--- a/glTF-Toolkit.UWP/packages.config
+++ b/glTF-Toolkit.UWP/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="directxtex_uwp" version="2017.12.13.1" targetFramework="native" />
-  <package id="Microsoft.glTF.CPP" version="1.3.26.0" targetFramework="native" />
+  <package id="directxtex_uwp" version="2018.2.9.1" targetFramework="native" />
+  <package id="Microsoft.glTF.CPP" version="1.3.46.0" targetFramework="native" />
   <package id="rapidjson.temprelease" version="0.0.2.20" targetFramework="native" />
 </packages>

--- a/glTF-Toolkit/glTF-Toolkit.vcxproj
+++ b/glTF-Toolkit/glTF-Toolkit.vcxproj
@@ -330,15 +330,15 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\rapidjson.temprelease.0.0.2.20\build\native\rapidjson.temprelease.targets" Condition="Exists('..\packages\rapidjson.temprelease.0.0.2.20\build\native\rapidjson.temprelease.targets')" />
-    <Import Project="..\packages\directxtex_desktop_2015.2017.12.13.1\build\native\directxtex_desktop_2015.targets" Condition="Exists('..\packages\directxtex_desktop_2015.2017.12.13.1\build\native\directxtex_desktop_2015.targets')" />
-    <Import Project="..\packages\Microsoft.glTF.CPP.1.3.26.0\build\native\Microsoft.glTF.CPP.targets" Condition="Exists('..\packages\Microsoft.glTF.CPP.1.3.26.0\build\native\Microsoft.glTF.CPP.targets')" />
+    <Import Project="..\packages\directxtex_desktop_2015.2018.2.9.1\build\native\directxtex_desktop_2015.targets" Condition="Exists('..\packages\directxtex_desktop_2015.2018.2.9.1\build\native\directxtex_desktop_2015.targets')" />
+    <Import Project="..\packages\Microsoft.glTF.CPP.1.3.46.0\build\native\Microsoft.glTF.CPP.targets" Condition="Exists('..\packages\Microsoft.glTF.CPP.1.3.46.0\build\native\Microsoft.glTF.CPP.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\rapidjson.temprelease.0.0.2.20\build\native\rapidjson.temprelease.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\rapidjson.temprelease.0.0.2.20\build\native\rapidjson.temprelease.targets'))" />
-    <Error Condition="!Exists('..\packages\directxtex_desktop_2015.2017.12.13.1\build\native\directxtex_desktop_2015.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\directxtex_desktop_2015.2017.12.13.1\build\native\directxtex_desktop_2015.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.glTF.CPP.1.3.26.0\build\native\Microsoft.glTF.CPP.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.glTF.CPP.1.3.26.0\build\native\Microsoft.glTF.CPP.targets'))" />
+    <Error Condition="!Exists('..\packages\directxtex_desktop_2015.2018.2.9.1\build\native\directxtex_desktop_2015.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\directxtex_desktop_2015.2018.2.9.1\build\native\directxtex_desktop_2015.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.glTF.CPP.1.3.46.0\build\native\Microsoft.glTF.CPP.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.glTF.CPP.1.3.46.0\build\native\Microsoft.glTF.CPP.targets'))" />
   </Target>
 </Project>

--- a/glTF-Toolkit/inc/GLTFLODUtils.h
+++ b/glTF-Toolkit/inc/GLTFLODUtils.h
@@ -32,7 +32,7 @@ namespace Microsoft::glTF::Toolkit
         /// <param name="docs">A vector of glTF documents to merge as LODs. The first element of the vector is assumed to be the primary LOD.</param>
         /// <param name="relativePaths">A vector of relative path prefixes to the non-LOD0 LOD gltf documents. Used for finding resources in those LODs.
         /// If not specified, all resources are assumed to be in the same directory.</param>
-        static GLTFDocument MergeDocumentsAsLODs(const std::vector<GLTFDocument>& docs, const std::vector<std::wstring>& relativePaths = std::vector<std::wstring>());
+        static GLTFDocument MergeDocumentsAsLODs(const std::vector<GLTFDocument>& docs, const std::vector<std::wstring>& relativePaths = std::vector<std::wstring>(), const bool& shared_materials = false);
 
         /// <summary>
         /// Inserts each LOD GLTFDocument as a node LOD (at the root level) of the specified primary GLTF asset.
@@ -44,7 +44,7 @@ namespace Microsoft::glTF::Toolkit
         /// vector is larger than the size of <see name="docs" />, lower coverage values will cause the asset to be invisible.</param>
         /// <param name="relativePaths">A vector of relative path prefixes to the non-LOD0 LOD gltf documents. Used for finding resources in those LODs.
         /// If not specified, all resources are assumed to be in the same directory.</param>
-        static GLTFDocument MergeDocumentsAsLODs(const std::vector<GLTFDocument>& docs, const std::vector<double>& screenCoveragePercentages, const std::vector<std::wstring>& relativePaths = std::vector<std::wstring>());
+        static GLTFDocument MergeDocumentsAsLODs(const std::vector<GLTFDocument>& docs, const std::vector<double>& screenCoveragePercentages, const std::vector<std::wstring>& relativePaths = std::vector<std::wstring>(), const bool& shared_materials = false);
 
         /// <summary>
         /// Determines the highest number of Node LODs for a given glTF asset.

--- a/glTF-Toolkit/inc/GLTFLODUtils.h
+++ b/glTF-Toolkit/inc/GLTFLODUtils.h
@@ -32,7 +32,7 @@ namespace Microsoft::glTF::Toolkit
         /// <param name="docs">A vector of glTF documents to merge as LODs. The first element of the vector is assumed to be the primary LOD.</param>
         /// <param name="relativePaths">A vector of relative path prefixes to the non-LOD0 LOD gltf documents. Used for finding resources in those LODs.
         /// If not specified, all resources are assumed to be in the same directory.</param>
-        static GLTFDocument MergeDocumentsAsLODs(const std::vector<GLTFDocument>& docs, const std::vector<std::wstring>& relativePaths = std::vector<std::wstring>(), const bool& shared_materials = false);
+        static GLTFDocument MergeDocumentsAsLODs(const std::vector<GLTFDocument>& docs, const std::vector<std::wstring>& relativePaths = std::vector<std::wstring>(), const bool& sharedMaterials = false);
 
         /// <summary>
         /// Inserts each LOD GLTFDocument as a node LOD (at the root level) of the specified primary GLTF asset.
@@ -44,7 +44,7 @@ namespace Microsoft::glTF::Toolkit
         /// vector is larger than the size of <see name="docs" />, lower coverage values will cause the asset to be invisible.</param>
         /// <param name="relativePaths">A vector of relative path prefixes to the non-LOD0 LOD gltf documents. Used for finding resources in those LODs.
         /// If not specified, all resources are assumed to be in the same directory.</param>
-        static GLTFDocument MergeDocumentsAsLODs(const std::vector<GLTFDocument>& docs, const std::vector<double>& screenCoveragePercentages, const std::vector<std::wstring>& relativePaths = std::vector<std::wstring>(), const bool& shared_materials = false);
+        static GLTFDocument MergeDocumentsAsLODs(const std::vector<GLTFDocument>& docs, const std::vector<double>& screenCoveragePercentages, const std::vector<std::wstring>& relativePaths = std::vector<std::wstring>(), const bool& sharedMaterials = false);
 
         /// <summary>
         /// Determines the highest number of Node LODs for a given glTF asset.

--- a/glTF-Toolkit/packages.config
+++ b/glTF-Toolkit/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="directxtex_desktop_2015" version="2017.12.13.1" targetFramework="native" />
-  <package id="Microsoft.glTF.CPP" version="1.3.26.0" targetFramework="native" />
+  <package id="directxtex_desktop_2015" version="2018.2.9.1" targetFramework="native" />
+  <package id="Microsoft.glTF.CPP" version="1.3.46.0" targetFramework="native" />
   <package id="rapidjson.temprelease" version="0.0.2.20" targetFramework="native" />
 </packages>

--- a/glTF-Toolkit/src/GLTFLODUtils.cpp
+++ b/glTF-Toolkit/src/GLTFLODUtils.cpp
@@ -336,7 +336,18 @@ namespace
                         auto iter = std::find_if(gltfLod.materials.Elements().begin(),
                                 gltfLod.materials.Elements().end(),
                                 [localMaterial](auto globalMaterial) {
-                                    return localMaterial.name == globalMaterial.name;
+                                    // check that the materials are the same, noting that the texture and material ids will differ
+                                    return localMaterial.name == globalMaterial.name &&
+                                           localMaterial.alphaMode == globalMaterial.alphaMode &&
+                                           localMaterial.alphaCutoff == globalMaterial.alphaCutoff &&
+                                           localMaterial.emissiveFactor == globalMaterial.emissiveFactor &&
+                                           localMaterial.doubleSided == globalMaterial.doubleSided &&
+                                           localMaterial.metallicRoughness.baseColorFactor == globalMaterial.metallicRoughness.baseColorFactor &&
+                                           localMaterial.metallicRoughness.metallicFactor == globalMaterial.metallicRoughness.metallicFactor &&
+                                           localMaterial.occlusionTexture.strength == globalMaterial.occlusionTexture.strength &&
+                                           localMaterial.specularGlossiness.diffuseFactor == globalMaterial.specularGlossiness.diffuseFactor &&
+                                           localMaterial.specularGlossiness.glossinessFactor == globalMaterial.specularGlossiness.glossinessFactor &&
+                                           localMaterial.specularGlossiness.specularFactor == globalMaterial.specularGlossiness.specularFactor;
                                 }
                         );
 

--- a/glTF-Toolkit/src/GLTFLODUtils.cpp
+++ b/glTF-Toolkit/src/GLTFLODUtils.cpp
@@ -325,7 +325,7 @@ namespace
                     AddIndexOffset(primitive.uv1AccessorId, accessorOffset);
                     AddIndexOffset(primitive.color0AccessorId, accessorOffset);
 
-                    if (shared_materials)
+                    if (sharedMaterials)
                     {
                         // lower quality LODs can have fewer images and textures than the highest LOD,
                         // so we need to find the correct material index for the same material from the highest LOD

--- a/glTF-Toolkit/src/GLTFLODUtils.cpp
+++ b/glTF-Toolkit/src/GLTFLODUtils.cpp
@@ -110,7 +110,7 @@ namespace
         return stringBuffer.GetString();
     }
 
-    GLTFDocument AddGLTFNodeLOD(const GLTFDocument& primary, LODMap& primaryLods, const GLTFDocument& lod, const std::wstring& relativePath = L"")
+    GLTFDocument AddGLTFNodeLOD(const GLTFDocument& primary, LODMap& primaryLods, const GLTFDocument& lod, const std::wstring& relativePath = L"", bool shared_materials = false)
     {
         Microsoft::glTF::GLTFDocument gltfLod(primary);
 
@@ -256,7 +256,8 @@ namespace
         // Material Merge
         // Note the extension KHR_materials_pbrSpecularGlossiness will be also updated
         // Materials depend upon textures
-        size_t materialOffset = gltfLod.materials.Size();
+        size_t materialOffset = shared_materials ? 0 : gltfLod.materials.Size();
+        if (!shared_materials)
         {
             auto lodMaterials = lod.materials.Elements();
             for (auto material : lodMaterials)
@@ -432,7 +433,7 @@ LODMap GLTFLODUtils::ParseDocumentNodeLODs(const GLTFDocument& doc)
     return lodMap;
 }
 
-GLTFDocument GLTFLODUtils::MergeDocumentsAsLODs(const std::vector<GLTFDocument>& docs, const std::vector<std::wstring>& relativePaths)
+GLTFDocument GLTFLODUtils::MergeDocumentsAsLODs(const std::vector<GLTFDocument>& docs, const std::vector<std::wstring>& relativePaths, const bool& shared_materials)
 {
     if (docs.empty())
     {
@@ -444,7 +445,7 @@ GLTFDocument GLTFLODUtils::MergeDocumentsAsLODs(const std::vector<GLTFDocument>&
 
     for (size_t i = 1; i < docs.size(); i++)
     {
-        gltfPrimary = AddGLTFNodeLOD(gltfPrimary, lods, docs[i], (relativePaths.size() == docs.size() - 1 ? relativePaths[i - 1] : L""));
+        gltfPrimary = AddGLTFNodeLOD(gltfPrimary, lods, docs[i], (relativePaths.size() == docs.size() - 1 ? relativePaths[i - 1] : L""), shared_materials);
     }
 
     for (auto lod : lods)
@@ -467,9 +468,9 @@ GLTFDocument GLTFLODUtils::MergeDocumentsAsLODs(const std::vector<GLTFDocument>&
     return gltfPrimary;
 }
 
-GLTFDocument GLTFLODUtils::MergeDocumentsAsLODs(const std::vector<GLTFDocument>& docs, const std::vector<double>& screenCoveragePercentages, const std::vector<std::wstring>& relativePaths)
+GLTFDocument GLTFLODUtils::MergeDocumentsAsLODs(const std::vector<GLTFDocument>& docs, const std::vector<double>& screenCoveragePercentages, const std::vector<std::wstring>& relativePaths, const bool& shared_materials)
 {
-    GLTFDocument merged = MergeDocumentsAsLODs(docs, relativePaths);
+    GLTFDocument merged = MergeDocumentsAsLODs(docs, relativePaths, shared_materials);
 
     if (screenCoveragePercentages.size() == 0)
     {

--- a/glTF-Toolkit/src/GLTFLODUtils.cpp
+++ b/glTF-Toolkit/src/GLTFLODUtils.cpp
@@ -110,7 +110,7 @@ namespace
         return stringBuffer.GetString();
     }
 
-    GLTFDocument AddGLTFNodeLOD(const GLTFDocument& primary, LODMap& primaryLods, const GLTFDocument& lod, const std::wstring& relativePath = L"", bool shared_materials = false)
+    GLTFDocument AddGLTFNodeLOD(const GLTFDocument& primary, LODMap& primaryLods, const GLTFDocument& lod, const std::wstring& relativePath = L"", bool sharedMaterials = false)
     {
         Microsoft::glTF::GLTFDocument gltfLod(primary);
 
@@ -156,7 +156,7 @@ namespace
         // lod merge is performed from the lowest reference back upwards
         // e.g. buffers/samplers/extensions do not reference any other part of the gltf manifest    
         size_t buffersOffset = gltfLod.buffers.Size();
-        size_t samplersOffset = shared_materials ? 0 : gltfLod.samplers.Size();
+        size_t samplersOffset = sharedMaterials ? 0 : gltfLod.samplers.Size();
         {
             auto lodBuffers = lod.buffers.Elements();
             for (auto buffer : lodBuffers)
@@ -167,7 +167,7 @@ namespace
                 gltfLod.buffers.Append(std::move(buffer));
             }
 
-            if (!shared_materials)
+            if (!sharedMaterials)
             {
                 auto lodSamplers = lod.samplers.Elements();
                 for (auto sampler : lodSamplers)
@@ -208,8 +208,8 @@ namespace
             }
 
             // Images depend upon Buffer views
-            size_t imageOffset = shared_materials ? 0 : gltfLod.images.Size();
-            if (!shared_materials)
+            size_t imageOffset = sharedMaterials ? 0 : gltfLod.images.Size();
+            if (!sharedMaterials)
             {
                 auto lodImages = lod.images.Elements();
                 for (auto image : lodImages)
@@ -263,8 +263,8 @@ namespace
         // Material Merge
         // Note the extension KHR_materials_pbrSpecularGlossiness will be also updated
         // Materials depend upon textures
-        size_t materialOffset = shared_materials ? 0 : gltfLod.materials.Size();
-        if (!shared_materials)
+        size_t materialOffset = sharedMaterials ? 0 : gltfLod.materials.Size();
+        if (!sharedMaterials)
         {
             auto lodMaterials = lod.materials.Elements();
             for (auto material : lodMaterials)
@@ -479,7 +479,7 @@ LODMap GLTFLODUtils::ParseDocumentNodeLODs(const GLTFDocument& doc)
     return lodMap;
 }
 
-GLTFDocument GLTFLODUtils::MergeDocumentsAsLODs(const std::vector<GLTFDocument>& docs, const std::vector<std::wstring>& relativePaths, const bool& shared_materials)
+GLTFDocument GLTFLODUtils::MergeDocumentsAsLODs(const std::vector<GLTFDocument>& docs, const std::vector<std::wstring>& relativePaths, const bool& sharedMaterials)
 {
     if (docs.empty())
     {
@@ -491,7 +491,7 @@ GLTFDocument GLTFLODUtils::MergeDocumentsAsLODs(const std::vector<GLTFDocument>&
 
     for (size_t i = 1; i < docs.size(); i++)
     {
-        gltfPrimary = AddGLTFNodeLOD(gltfPrimary, lods, docs[i], (relativePaths.size() == docs.size() - 1 ? relativePaths[i - 1] : L""), shared_materials);
+        gltfPrimary = AddGLTFNodeLOD(gltfPrimary, lods, docs[i], (relativePaths.size() == docs.size() - 1 ? relativePaths[i - 1] : L""), sharedMaterials);
     }
 
     for (auto lod : lods)
@@ -514,9 +514,9 @@ GLTFDocument GLTFLODUtils::MergeDocumentsAsLODs(const std::vector<GLTFDocument>&
     return gltfPrimary;
 }
 
-GLTFDocument GLTFLODUtils::MergeDocumentsAsLODs(const std::vector<GLTFDocument>& docs, const std::vector<double>& screenCoveragePercentages, const std::vector<std::wstring>& relativePaths, const bool& shared_materials)
+GLTFDocument GLTFLODUtils::MergeDocumentsAsLODs(const std::vector<GLTFDocument>& docs, const std::vector<double>& screenCoveragePercentages, const std::vector<std::wstring>& relativePaths, const bool& sharedMaterials)
 {
-    GLTFDocument merged = MergeDocumentsAsLODs(docs, relativePaths, shared_materials);
+    GLTFDocument merged = MergeDocumentsAsLODs(docs, relativePaths, sharedMaterials);
 
     if (screenCoveragePercentages.size() == 0)
     {

--- a/glTF-Toolkit/src/GLTFTextureCompressionUtils.cpp
+++ b/glTF-Toolkit/src/GLTFTextureCompressionUtils.cpp
@@ -254,19 +254,26 @@ void GLTFTextureCompressionUtils::CompressImage(DirectX::ScratchImage& image, Te
         break;
     }
 
-    DX::DeviceResources deviceResources;
-    deviceResources.CreateDeviceResources();
-    ComPtr<ID3D11Device> device(deviceResources.GetD3DDevice());
-    
+    bool gpuCompressionSuccessful = false;
     DirectX::ScratchImage compressedImage;
 
-    bool gpuCompressionSuccessful = false;
-    if (device != nullptr)
+    try
     {
-        if (SUCCEEDED(DirectX::Compress(device.Get(), image.GetImages(), image.GetImageCount(), image.GetMetadata(), compressionFormat, DirectX::TEX_COMPRESS_DEFAULT, 0, compressedImage)))
+        DX::DeviceResources deviceResources;
+        deviceResources.CreateDeviceResources();
+        ComPtr<ID3D11Device> device(deviceResources.GetD3DDevice());
+
+        if (device != nullptr)
         {
-            gpuCompressionSuccessful = true;
+            if (SUCCEEDED(DirectX::Compress(device.Get(), image.GetImages(), image.GetImageCount(), image.GetMetadata(), compressionFormat, DirectX::TEX_COMPRESS_DEFAULT, 0, compressedImage)))
+            {
+                gpuCompressionSuccessful = true;
+            }
         }
+    }
+    catch (std::exception e)
+    {
+        // Failed to initialize device - GPU is not available
     }
 
     if (!gpuCompressionSuccessful)

--- a/glTF-Toolkit/src/SerializeBinary.cpp
+++ b/glTF-Toolkit/src/SerializeBinary.cpp
@@ -53,7 +53,7 @@ namespace
             max = minmax.second;
         }
 
-        builder.AddAccessor(accessorContents, accessor.componentType, accessor.type, min, max);
+        builder.AddAccessor(accessorContents, AccessorDesc(accessor.type, accessor.componentType, accessor.normalized, min, max));
     }
 
     template <typename OriginalType, typename NewType>


### PR DESCRIPTION
Fixes part of issue #9 by adding a commandline flag that bypasses packing of texture resources for the lower LOD levels, and that makes the lower LODs use the materials from LOD0.

The assumption is that LOD0 has all the materials used for all the LODs, and the lower quality LODs may use a subset of the materials from LOD0. It also assumes that the same texture packing scheme is used for all LODs.

