### PR TITLE
Reset parser state on encountering "-share-materials"

### DIFF
--- a/WindowsMRAssetConverter/CommandLine.cpp
+++ b/WindowsMRAssetConverter/CommandLine.cpp
@@ -117,6 +117,7 @@ void CommandLine::ParseCommandLineArguments(
         else if (param == PARAM_SHARE_MATERIALS)
         {
             shareMaterials = true;
+            state = CommandLineParsingState::Initial;
         }
         else
         {


### PR DESCRIPTION
The parser would otherwise continue in whatever old state it's in, causing issues.