### PR TITLE
Improve serialize binary

### DIFF
--- a/glTF-Toolkit/inc/SerializeBinary.h
+++ b/glTF-Toolkit/inc/SerializeBinary.h
@@ -2,8 +2,9 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.#pragma once
 
 #include <GLTFSDK/GLTFDocument.h>
-#include <GLTFSDK/IStreamReader.h>
+#include <GLTFSDK/GLTFResourceReader.h>
 #include <GLTFSDK/IStreamFactory.h>
+#include <GLTFSDK/IStreamReader.h>
 #include <GLTFSDK/RapidJsonUtils.h>
 #include <functional>
 #include <memory>
@@ -24,7 +25,16 @@ namespace Microsoft::glTF::Toolkit
     /// </summary>
     /// <param name="gltfDocument">The glTF asset manifest to be serialized.</param>
     /// <param name="inputStreamReader">A stream reader that is capable of accessing the resources used in the glTF asset by URI.</param>
-    /// <param name="outputStreamFactory">A stream factory that is capable of creating an output stream where the GLB will be saved, and a temporary stream for 
+    /// <param name="outputStreamFactory">A stream factory that is capable of creating an output stream where the GLB will be saved, and a temporary stream for
     /// use during the serialization process.</param>
     void SerializeBinary(const GLTFDocument& gltfDocument, const IStreamReader& inputStreamReader, std::unique_ptr<const IStreamFactory>& outputStreamFactory, const AccessorConversionStrategy& accessorConversion = nullptr);
+
+    /// <summary>
+    /// Serializes a glTF asset as a glTF binary (GLB) file.
+    /// </summary>
+    /// <param name="gltfDocument">The glTF asset manifest to be serialized.</param>
+    /// <param name="resourceReader">A resource reader that is capable of accessing the resources used in the document.</param>
+    /// <param name="outputStreamFactory">A stream factory that is capable of creating an output stream where the GLB will be saved, and a temporary stream for
+    /// use during the serialization process.</param>
+    void SerializeBinary(const GLTFDocument& gltfDocument, const GLTFResourceReader& resourceReader, std::unique_ptr<const IStreamFactory>& outputStreamFactory, const AccessorConversionStrategy& accessorConversion = nullptr);
 }


### PR DESCRIPTION
This change allows SerializeBinary to serialize a GLTFDocument which was loaded from a GLB.

- Callers can now specify a GLBResourceReader (subclass of GLTFResourceReader) when serializing.

- Fixes a bug where a bufferview would not be copied to the output document if it were referenced only by images with URIs