### PR TITLE
Update SerializeBinary to accept an rvalue for for GLBStreamFactor

### DIFF
--- a/WindowsMRAssetConverter/WindowsMRAssetConverter.cpp
+++ b/WindowsMRAssetConverter/WindowsMRAssetConverter.cpp
@@ -252,8 +252,7 @@ int wmain(int argc, wchar_t *argv[])
         };
 
         GLTFStreamReader streamReader(FileSystem::GetBasePath(inputFilePath));
-        std::unique_ptr<const IStreamFactory> streamFactory = std::make_unique<GLBStreamFactory>(outFilePath);
-        SerializeBinary(document, streamReader, streamFactory, accessorConversion);
+        SerializeBinary(document, streamReader, std::make_unique<GLBStreamFactory>(outFilePath), accessorConversion);
 
         std::wcout << L"Done!" << std::endl;
         std::wcout << L"Output file: " << outFilePath << std::endl;

--- a/glTF-Toolkit.Test/GLBSerializerTests.cpp
+++ b/glTF-Toolkit.Test/GLBSerializerTests.cpp
@@ -95,8 +95,7 @@ namespace Microsoft::glTF::Toolkit::Test
                 // Serialize GLTFDocument to GLB
                 TestStreamReader streamReader(TestUtils::GetAbsolutePath(c_waterBottleJson));
                 auto stream = std::make_shared<std::stringstream>(std::ios_base::app | std::ios_base::binary | std::ios_base::in | std::ios_base::out);
-                std::unique_ptr<const IStreamFactory> streamFactory = std::make_unique<InMemoryStreamFactory>(stream);
-                SerializeBinary(doc, streamReader, streamFactory);
+                SerializeBinary(doc, streamReader, std::make_unique<InMemoryStreamFactory>(stream));
 
                 // Deserialize the GLB again
                 auto glbReader = std::make_unique<GLBResourceReader>(streamReader, stream);

--- a/glTF-Toolkit.UWP/GLTFSerialization.cpp
+++ b/glTF-Toolkit.UWP/GLTFSerialization.cpp
@@ -61,8 +61,7 @@ IAsyncOperation<StorageFile^>^ GLTFSerialization::PackGLTFAsync(StorageFile^ sou
 
                 String^ outputGlbPath = outputFolder->Path + "\\" + glbName;
                 std::wstring outputGlbPathW = outputGlbPath->Data();
-                std::unique_ptr<const IStreamFactory> streamFactory = std::make_unique<GLBStreamFactory>(outputGlbPathW);
-                SerializeBinary(*document, streamReader, streamFactory);
+                SerializeBinary(*document, streamReader, std::make_unique<GLBStreamFactory>(outputGlbPathW));
 
                 return outputFolder->GetFileAsync(glbName);
             });

--- a/glTF-Toolkit.UWP/WindowsMRConversion.cpp
+++ b/glTF-Toolkit.UWP/WindowsMRConversion.cpp
@@ -125,8 +125,7 @@ IAsyncOperation<StorageFile^>^ WindowsMRConversion::ConvertAssetForWindowsMR(Sto
                 glbName += L".glb";
 
                 std::wstring outputGlbPathW = std::wstring(outputFolder->Path->Data()) + L"\\" + glbName;
-                std::unique_ptr<const IStreamFactory> streamFactory = std::make_unique<GLBStreamFactory>(outputGlbPathW);
-                SerializeBinary(convertedDoc, streamReader, streamFactory, accessorConversion);
+                SerializeBinary(convertedDoc, streamReader, std::make_unique<GLBStreamFactory>(outputGlbPathW), accessorConversion);
 
                 return create_task(outputFolder->GetFileAsync(ref new String(glbName.c_str())));
             });

--- a/glTF-Toolkit/inc/SerializeBinary.h
+++ b/glTF-Toolkit/inc/SerializeBinary.h
@@ -27,7 +27,7 @@ namespace Microsoft::glTF::Toolkit
     /// <param name="inputStreamReader">A stream reader that is capable of accessing the resources used in the glTF asset by URI.</param>
     /// <param name="outputStreamFactory">A stream factory that is capable of creating an output stream where the GLB will be saved, and a temporary stream for
     /// use during the serialization process.</param>
-    void SerializeBinary(const GLTFDocument& gltfDocument, const IStreamReader& inputStreamReader, std::unique_ptr<const IStreamFactory>& outputStreamFactory, const AccessorConversionStrategy& accessorConversion = nullptr);
+    void SerializeBinary(const GLTFDocument& gltfDocument, const IStreamReader& inputStreamReader, std::unique_ptr<const IStreamFactory>&& outputStreamFactory, const AccessorConversionStrategy& accessorConversion = nullptr);
 
     /// <summary>
     /// Serializes a glTF asset as a glTF binary (GLB) file.
@@ -36,5 +36,5 @@ namespace Microsoft::glTF::Toolkit
     /// <param name="resourceReader">A resource reader that is capable of accessing the resources used in the document.</param>
     /// <param name="outputStreamFactory">A stream factory that is capable of creating an output stream where the GLB will be saved, and a temporary stream for
     /// use during the serialization process.</param>
-    void SerializeBinary(const GLTFDocument& gltfDocument, const GLTFResourceReader& resourceReader, std::unique_ptr<const IStreamFactory>& outputStreamFactory, const AccessorConversionStrategy& accessorConversion = nullptr);
+    void SerializeBinary(const GLTFDocument& gltfDocument, const GLTFResourceReader& resourceReader, std::unique_ptr<const IStreamFactory>&& outputStreamFactory, const AccessorConversionStrategy& accessorConversion = nullptr);
 }

--- a/glTF-Toolkit/src/SerializeBinary.cpp
+++ b/glTF-Toolkit/src/SerializeBinary.cpp
@@ -151,7 +151,7 @@ namespace
 
 void Microsoft::glTF::Toolkit::SerializeBinary(const GLTFDocument& gltfDocument,
                                                const GLTFResourceReader& resourceReader,
-                                               std::unique_ptr<const IStreamFactory>& outputStreamFactory,
+                                               std::unique_ptr<const IStreamFactory>&& outputStreamFactory,
                                                const AccessorConversionStrategy& accessorConversion)
 {
     auto writer = std::make_unique<GLBResourceWriter2>(std::move(outputStreamFactory), std::string());
@@ -218,8 +218,8 @@ void Microsoft::glTF::Toolkit::SerializeBinary(const GLTFDocument& gltfDocument,
 }
 
 void Microsoft::glTF::Toolkit::SerializeBinary(const GLTFDocument& gltfDocument, const IStreamReader& inputStreamReader,
-                                               std::unique_ptr<const IStreamFactory>& outputStreamFactory,
+                                               std::unique_ptr<const IStreamFactory>&& outputStreamFactory,
                                                const AccessorConversionStrategy& accessorConversion)
 {
-    SerializeBinary(gltfDocument, GLTFResourceReader{inputStreamReader}, outputStreamFactory, accessorConversion);
+    SerializeBinary(gltfDocument, GLTFResourceReader{inputStreamReader}, std::move(outputStreamFactory), accessorConversion);
 }


### PR DESCRIPTION
Since SerializeBinary will eventually invoke the move constructor of its std::unique_ptr<IStreamFactory> parameter, it would be more correct to only allow the parameter to bind to an rvalue.

This prevents the parameter from being expected to outlive the call, and allows the function to be called in a more natural way - one that doesn't require an intermediate stack variable that is unusable after the call.
