### PR TITLE
Mesh compression

### DIFF
--- a/WindowsMRAssetConverter/CommandLine.cpp
+++ b/WindowsMRAssetConverter/CommandLine.cpp
@@ -17,8 +17,10 @@ const wchar_t * PARAM_PLATFORM = L"-platform";
 const wchar_t * PARAM_REPLACE_TEXTURES = L"-replace-textures";
 const wchar_t * PARAM_VALUE_VERSION_1709 = L"1709";
 const wchar_t * PARAM_VALUE_VERSION_1803 = L"1803";
+const wchar_t * PARAM_VALUE_VERSION_1809 = L"1809";
 const wchar_t * PARAM_VALUE_VERSION_RS3 = L"rs3";
 const wchar_t * PARAM_VALUE_VERSION_RS4 = L"rs4";
+const wchar_t * PARAM_VALUE_VERSION_RS5 = L"rs5";
 const wchar_t * PARAM_VALUE_VERSION_LATEST = L"latest";
 const wchar_t * PARAM_VALUE_HOLOGRAPHIC = L"holographic";
 const wchar_t * PARAM_VALUE_HOLOLENS= L"hololens";
@@ -60,7 +62,7 @@ void CommandLine::PrintHelp()
         << indent << "[" << std::wstring(PARAM_OUTFILE) << L" <output file path>]" << std::endl
         << indent << "[" << std::wstring(PARAM_TMPDIR) << L" <temporary folder>] - default is the system temp folder for the user" << std::endl
         << indent << "[" << std::wstring(PARAM_PLATFORM) << " <" << PARAM_VALUE_ALL << " | " << PARAM_VALUE_HOLOGRAPHIC << " | " << PARAM_VALUE_DESKTOP << ">] - defaults to " << PARAM_VALUE_DESKTOP << std::endl
-        << indent << "[" << std::wstring(PARAM_MIN_VERSION) << " <" << PARAM_VALUE_VERSION_1709 << " | " << PARAM_VALUE_VERSION_1803 << " | " << PARAM_VALUE_VERSION_LATEST << ">] - defaults to " << PARAM_VALUE_VERSION_1709 << std::endl
+        << indent << "[" << std::wstring(PARAM_MIN_VERSION) << " <" << PARAM_VALUE_VERSION_1709 << " | " << PARAM_VALUE_VERSION_1803 << " | " << PARAM_VALUE_VERSION_1809 << " | " << PARAM_VALUE_VERSION_LATEST << ">] - defaults to " << PARAM_VALUE_VERSION_1709 << std::endl
         << indent << "[" << std::wstring(PARAM_LOD) << " <path to each lower LOD asset in descending order of quality>]" << std::endl
         << indent << "[" << std::wstring(PARAM_SCREENCOVERAGE) << " <LOD screen coverage values>]" << std::endl
         << indent << "[" << std::wstring(PARAM_SHARE_MATERIALS) << "] - disabled if not present" << std::endl
@@ -189,6 +191,10 @@ void CommandLine::ParseCommandLineArguments(
                 else if (_wcsicmp(param.c_str(), PARAM_VALUE_VERSION_1803) == 0 || _wcsicmp(param.c_str(), PARAM_VALUE_VERSION_RS4) == 0)
                 {
                     minVersion = Version::Version1803;
+                }
+                else if (_wcsicmp(param.c_str(), PARAM_VALUE_VERSION_1809) == 0 || _wcsicmp(param.c_str(), PARAM_VALUE_VERSION_RS5) == 0)
+                {
+                    minVersion = Version::Version1809;
                 }
                 else if (_wcsicmp(param.c_str(), PARAM_VALUE_VERSION_LATEST) == 0)
                 {

--- a/WindowsMRAssetConverter/CommandLine.h
+++ b/WindowsMRAssetConverter/CommandLine.h
@@ -19,7 +19,8 @@ namespace CommandLine
     {
         Version1709, // Fall Creators Update (RS3)
         Version1803,  // Spring Creators Update (RS4)
-        Latest = Version1803
+        Version1809,  // Fall 2018 Update (RS5)
+        Latest = Version1809
     };
 
     void PrintHelp();

--- a/WindowsMRAssetConverter/WindowsMRAssetConverter.vcxproj
+++ b/WindowsMRAssetConverter/WindowsMRAssetConverter.vcxproj
@@ -208,6 +208,7 @@
     <Import Project="..\packages\rapidjson.temprelease.0.0.2.20\build\native\rapidjson.temprelease.targets" Condition="Exists('..\packages\rapidjson.temprelease.0.0.2.20\build\native\rapidjson.temprelease.targets')" />
     <Import Project="..\packages\directxtex_desktop_2015.2018.6.1.2\build\native\directxtex_desktop_2015.targets" Condition="Exists('..\packages\directxtex_desktop_2015.2018.6.1.2\build\native\directxtex_desktop_2015.targets')" />
     <Import Project="..\packages\Microsoft.glTF.CPP.1.5.19.0\build\native\Microsoft.glTF.CPP.targets" Condition="Exists('..\packages\Microsoft.glTF.CPP.1.5.19.0\build\native\Microsoft.glTF.CPP.targets')" />
+    <Import Project="..\packages\draco.CPP.1.3.3.0\build\native\draco.CPP.targets" Condition="Exists('..\packages\draco.CPP.1.3.3.0\build\native\draco.CPP.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -216,5 +217,6 @@
     <Error Condition="!Exists('..\packages\rapidjson.temprelease.0.0.2.20\build\native\rapidjson.temprelease.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\rapidjson.temprelease.0.0.2.20\build\native\rapidjson.temprelease.targets'))" />
     <Error Condition="!Exists('..\packages\directxtex_desktop_2015.2018.6.1.2\build\native\directxtex_desktop_2015.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\directxtex_desktop_2015.2018.6.1.2\build\native\directxtex_desktop_2015.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.glTF.CPP.1.5.19.0\build\native\Microsoft.glTF.CPP.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.glTF.CPP.1.5.19.0\build\native\Microsoft.glTF.CPP.targets'))" />
+    <Error Condition="!Exists('..\packages\draco.CPP.1.3.3.0\build\native\draco.CPP.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\draco.CPP.1.3.3.0\build\native\draco.CPP.targets'))" />
   </Target>
 </Project>

--- a/WindowsMRAssetConverter/WindowsMRAssetConverter.vcxproj
+++ b/WindowsMRAssetConverter/WindowsMRAssetConverter.vcxproj
@@ -206,15 +206,15 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\rapidjson.temprelease.0.0.2.20\build\native\rapidjson.temprelease.targets" Condition="Exists('..\packages\rapidjson.temprelease.0.0.2.20\build\native\rapidjson.temprelease.targets')" />
-    <Import Project="..\packages\directxtex_desktop_2015.2018.2.9.1\build\native\directxtex_desktop_2015.targets" Condition="Exists('..\packages\directxtex_desktop_2015.2018.2.9.1\build\native\directxtex_desktop_2015.targets')" />
-    <Import Project="..\packages\Microsoft.glTF.CPP.1.3.46.0\build\native\Microsoft.glTF.CPP.targets" Condition="Exists('..\packages\Microsoft.glTF.CPP.1.3.46.0\build\native\Microsoft.glTF.CPP.targets')" />
+    <Import Project="..\packages\directxtex_desktop_2015.2018.6.1.2\build\native\directxtex_desktop_2015.targets" Condition="Exists('..\packages\directxtex_desktop_2015.2018.6.1.2\build\native\directxtex_desktop_2015.targets')" />
+    <Import Project="..\packages\Microsoft.glTF.CPP.1.5.19.0\build\native\Microsoft.glTF.CPP.targets" Condition="Exists('..\packages\Microsoft.glTF.CPP.1.5.19.0\build\native\Microsoft.glTF.CPP.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\rapidjson.temprelease.0.0.2.20\build\native\rapidjson.temprelease.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\rapidjson.temprelease.0.0.2.20\build\native\rapidjson.temprelease.targets'))" />
-    <Error Condition="!Exists('..\packages\directxtex_desktop_2015.2018.2.9.1\build\native\directxtex_desktop_2015.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\directxtex_desktop_2015.2018.2.9.1\build\native\directxtex_desktop_2015.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.glTF.CPP.1.3.46.0\build\native\Microsoft.glTF.CPP.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.glTF.CPP.1.3.46.0\build\native\Microsoft.glTF.CPP.targets'))" />
+    <Error Condition="!Exists('..\packages\directxtex_desktop_2015.2018.6.1.2\build\native\directxtex_desktop_2015.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\directxtex_desktop_2015.2018.6.1.2\build\native\directxtex_desktop_2015.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.glTF.CPP.1.5.19.0\build\native\Microsoft.glTF.CPP.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.glTF.CPP.1.5.19.0\build\native\Microsoft.glTF.CPP.targets'))" />
   </Target>
 </Project>

--- a/WindowsMRAssetConverter/packages.config
+++ b/WindowsMRAssetConverter/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="directxtex_desktop_2015" version="2018.6.1.2" targetFramework="native" />
+  <package id="draco.CPP" version="1.3.3.0" targetFramework="native" />
   <package id="Microsoft.glTF.CPP" version="1.5.19.0" targetFramework="native" />
   <package id="rapidjson.temprelease" version="0.0.2.20" targetFramework="native" />
 </packages>

--- a/WindowsMRAssetConverter/packages.config
+++ b/WindowsMRAssetConverter/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="directxtex_desktop_2015" version="2018.2.9.1" targetFramework="native" />
-  <package id="Microsoft.glTF.CPP" version="1.3.46.0" targetFramework="native" />
+  <package id="directxtex_desktop_2015" version="2018.6.1.2" targetFramework="native" />
+  <package id="Microsoft.glTF.CPP" version="1.5.19.0" targetFramework="native" />
   <package id="rapidjson.temprelease" version="0.0.2.20" targetFramework="native" />
 </packages>

--- a/glTF-Toolkit.Test/GLBtoGLTFTests.cpp
+++ b/glTF-Toolkit.Test/GLBtoGLTFTests.cpp
@@ -5,7 +5,7 @@
 #include <CppUnitTest.h>  
 
 #include <numeric>
-#include <GLTFSDK/GLTFDocument.h>
+#include <GLTFSDK/Document.h>
 #include <GLTFSDK/Deserialize.h>
 #include <GLTFSDK/Serialize.h>
 #include <GLBtoGLTF.h>
@@ -37,9 +37,9 @@ namespace Microsoft::glTF::Toolkit::Test
     }
 
     // Setup a GLTF document with 3 bufferviews and 2 images
-    GLTFDocument setupGLBDocument1()
+    Document setupGLBDocument1()
     {
-        GLTFDocument glbDoc("0", {});
+        Document glbDoc;
         Scene sc; sc.id = "0";
         glbDoc.scenes.Append(std::move(sc));
         Accessor acc0; acc0.bufferViewId = "0"; acc0.byteOffset = 0; acc0.id = "0";
@@ -88,7 +88,7 @@ namespace Microsoft::glTF::Toolkit::Test
     {
         TEST_METHOD(GLBtoGLTF_NoImagesJSON)
         {
-            GLTFDocument glbDoc("0", {});
+            Document glbDoc;
             Scene s1; s1.id = "0";
             glbDoc.scenes.Append(std::move(s1));
             Accessor acc; acc.bufferViewId = "0"; acc.byteOffset = 36; acc.id = "0";
@@ -112,7 +112,7 @@ namespace Microsoft::glTF::Toolkit::Test
             {
                 glbDoc.images.Append(std::move(img));
             });
-            GLTFDocument expectedGLTFDoc("0", {});
+            Document expectedGLTFDoc;
             Scene s2; s2.id = "0";
             expectedGLTFDoc.scenes.Append(std::move(s2));
             auto actualGLTFDoc = GLBToGLTF::CreateGLTFDocument(glbDoc, "name");
@@ -125,7 +125,7 @@ namespace Microsoft::glTF::Toolkit::Test
 
         TEST_METHOD(GLBtoGLTF_ImagesWithOffsetJSON)
         {
-            GLTFDocument glbDoc("0", {});
+            Document glbDoc;
             Scene sc; sc.id = "0";
             glbDoc.scenes.Append(std::move(sc));
             Accessor acc0; acc0.bufferViewId = "0"; acc0.byteOffset = 0; acc0.id = "0";
@@ -161,7 +161,7 @@ namespace Microsoft::glTF::Toolkit::Test
             });
             auto actualGLTFDoc = GLBToGLTF::CreateGLTFDocument(glbDoc, "test");
 
-            GLTFDocument expectedGLTFDoc("0", {});
+            Document expectedGLTFDoc;
             Accessor exp_acc0; exp_acc0.bufferViewId = "0"; exp_acc0.byteOffset = 0; exp_acc0.id = "0";
             Accessor exp_acc1; exp_acc1.bufferViewId = "1"; exp_acc1.byteOffset = 4; exp_acc1.id = "3";
             expectedGLTFDoc.accessors.Append(std::move(exp_acc0));

--- a/glTF-Toolkit.Test/GLTFTextureCompressionUtilsTests.cpp
+++ b/glTF-Toolkit.Test/GLTFTextureCompressionUtilsTests.cpp
@@ -4,7 +4,7 @@
 #include <CppUnitTest.h>  
 
 #include "GLTFSDK/IStreamWriter.h"
-#include "GLTFSDK/GLTFConstants.h"
+#include "GLTFSDK/Constants.h"
 #include "GLTFSDK/Serialize.h"
 #include "GLTFSDK/Deserialize.h"
 #include "GLTFSDK/GLBResourceReader.h"
@@ -63,7 +63,7 @@ namespace Microsoft::glTF::Toolkit::Test
             // This asset has all textures
             TestUtils::LoadAndExecuteGLTFTest(c_waterBottleORMJson, [](auto doc, auto path)
             {
-                auto compressedDoc = GLTFTextureCompressionUtils::CompressTextureAsDDS(TestStreamReader(path), doc, doc.textures.Get("0"), TextureCompression::None, "");
+                auto compressedDoc = GLTFTextureCompressionUtils::CompressTextureAsDDS(std::make_shared<TestStreamReader>(path), doc, doc.textures.Get("0"), TextureCompression::None, "");
 
                 // Check that nothing changed
                 Assert::IsTrue(doc == compressedDoc);
@@ -78,7 +78,7 @@ namespace Microsoft::glTF::Toolkit::Test
                 auto maxTextureSize = std::numeric_limits<size_t>::max();
                 auto generateMipMaps = false;
                 auto retainOriginalImages = true;
-                auto compressedDoc = GLTFTextureCompressionUtils::CompressTextureAsDDS(TestStreamReader(path), doc, doc.textures.Get("0"), TextureCompression::BC3, "", maxTextureSize, generateMipMaps, retainOriginalImages);
+                auto compressedDoc = GLTFTextureCompressionUtils::CompressTextureAsDDS(std::make_shared<TestStreamReader>(path), doc, doc.textures.Get("0"), TextureCompression::BC3, "", maxTextureSize, generateMipMaps, retainOriginalImages);
 
                 auto originalTexture = doc.textures.Get("0");
                 auto compressedTexture = compressedDoc.textures.Get("0");
@@ -117,7 +117,7 @@ namespace Microsoft::glTF::Toolkit::Test
                 auto maxTextureSize = std::numeric_limits<size_t>::max();
                 auto generateMipMaps = false;
                 auto retainOriginalImages = false;
-                auto compressedDoc = GLTFTextureCompressionUtils::CompressTextureAsDDS(TestStreamReader(path), doc, doc.textures.Get("0"), TextureCompression::BC3, "", maxTextureSize, generateMipMaps, retainOriginalImages);
+                auto compressedDoc = GLTFTextureCompressionUtils::CompressTextureAsDDS(std::make_shared<TestStreamReader>(path), doc, doc.textures.Get("0"), TextureCompression::BC3, "", maxTextureSize, generateMipMaps, retainOriginalImages);
 
                 auto originalTexture = doc.textures.Get("0");
                 auto compressedTexture = compressedDoc.textures.Get("0");
@@ -159,7 +159,7 @@ namespace Microsoft::glTF::Toolkit::Test
                 auto maxTextureSize = std::numeric_limits<size_t>::max();
                 auto generateMipMaps = true;
                 auto retainOriginalImages = true;
-                auto compressedDoc = GLTFTextureCompressionUtils::CompressTextureAsDDS(TestStreamReader(path), doc, doc.textures.Get("0"), TextureCompression::BC7, "", maxTextureSize, generateMipMaps, retainOriginalImages);
+                auto compressedDoc = GLTFTextureCompressionUtils::CompressTextureAsDDS(std::make_shared<TestStreamReader>(path), doc, doc.textures.Get("0"), TextureCompression::BC7, "", maxTextureSize, generateMipMaps, retainOriginalImages);
 
                 auto originalTexture = doc.textures.Get("0");
                 auto compressedTexture = compressedDoc.textures.Get("0");
@@ -197,7 +197,7 @@ namespace Microsoft::glTF::Toolkit::Test
             {
                 auto maxTextureSize = std::numeric_limits<size_t>::max();
                 auto retainOriginalImages = true;
-                auto compressedDoc = GLTFTextureCompressionUtils::CompressAllTexturesForWindowsMR(TestStreamReader(path), doc, "", maxTextureSize, retainOriginalImages);
+                auto compressedDoc = GLTFTextureCompressionUtils::CompressAllTexturesForWindowsMR(std::make_shared<TestStreamReader>(path), doc, "", maxTextureSize, retainOriginalImages);
 
                 // Check that the materials and textures have not been replaced
                 // Check that the textures has not been replaced
@@ -211,12 +211,12 @@ namespace Microsoft::glTF::Toolkit::Test
                 auto compressedMaterial = compressedDoc.materials.Get("0");
 
                 // Check that all relevant textures now have the extension
-                Assert::IsTrue(doc.textures.Get(originalMaterial.metallicRoughness.baseColorTextureId).extensions.size() + 1 == compressedDoc.textures.Get(compressedMaterial.metallicRoughness.baseColorTextureId).extensions.size());
-                Assert::IsTrue(doc.textures.Get(originalMaterial.emissiveTextureId).extensions.size() + 1 == compressedDoc.textures.Get(compressedMaterial.emissiveTextureId).extensions.size());
+                Assert::IsTrue(doc.textures.Get(originalMaterial.metallicRoughness.baseColorTexture.textureId).extensions.size() + 1 == compressedDoc.textures.Get(compressedMaterial.metallicRoughness.baseColorTexture.textureId).extensions.size());
+                Assert::IsTrue(doc.textures.Get(originalMaterial.emissiveTexture.textureId).extensions.size() + 1 == compressedDoc.textures.Get(compressedMaterial.emissiveTexture.textureId).extensions.size());
                 // TODO: read the WMR (MSFT_packing...) textures as well
 
                 // Check the new extension is not empty
-                auto ddsExtension = compressedDoc.textures.Get(compressedMaterial.emissiveTextureId).extensions.at(std::string(EXTENSION_MSFT_TEXTURE_DDS));
+                auto ddsExtension = compressedDoc.textures.Get(compressedMaterial.emissiveTexture.textureId).extensions.at(std::string(EXTENSION_MSFT_TEXTURE_DDS));
                 Assert::IsFalse(ddsExtension.empty());
 
                 // Check the new extension contains a DDS image
@@ -241,7 +241,7 @@ namespace Microsoft::glTF::Toolkit::Test
                 auto maxTextureSize = std::numeric_limits<size_t>::max();
                 auto generateMipMaps = false;
                 auto retainOriginalImages = true;
-                auto compressedDoc = GLTFTextureCompressionUtils::CompressTextureAsDDS(TestStreamReader(path), doc, doc.textures.Get("0"), TextureCompression::BC3, "", maxTextureSize, generateMipMaps, retainOriginalImages);
+                auto compressedDoc = GLTFTextureCompressionUtils::CompressTextureAsDDS(std::make_shared<TestStreamReader>(path), doc, doc.textures.Get("0"), TextureCompression::BC3, "", maxTextureSize, generateMipMaps, retainOriginalImages);
 
                 auto originalUri = compressedDoc.images.Get("0").uri;
                 auto compressedUri = compressedDoc.images.Get("1").uri;

--- a/glTF-Toolkit.Test/GLTFTexturePackingUtilsTests.cpp
+++ b/glTF-Toolkit.Test/GLTFTexturePackingUtilsTests.cpp
@@ -4,7 +4,7 @@
 #include <CppUnitTest.h>  
 
 #include "GLTFSDK/IStreamWriter.h"
-#include "GLTFSDK/GLTFConstants.h"
+#include "GLTFSDK/Constants.h"
 #include "GLTFSDK/Serialize.h"
 #include "GLTFSDK/Deserialize.h"
 #include "GLTFSDK/GLBResourceReader.h"
@@ -36,7 +36,7 @@ namespace Microsoft::glTF::Toolkit::Test
             TestUtils::LoadAndExecuteGLTFTest(gltfRelativePath, [packing](auto doc, auto path)
             {
                 auto material = doc.materials.Elements()[0];
-                auto packedDoc = GLTFTexturePackingUtils::PackMaterialForWindowsMR(TestStreamReader(path), doc, material, packing, "");
+                auto packedDoc = GLTFTexturePackingUtils::PackMaterialForWindowsMR(std::make_shared<TestStreamReader>(path), doc, material, packing, "");
                 auto packedMaterial = packedDoc.materials.Elements()[0];
 
                 // Check that the material changed
@@ -72,7 +72,7 @@ namespace Microsoft::glTF::Toolkit::Test
                         Assert::IsTrue(ormJson[MSFT_PACKING_ORM_RMOTEXTURE_KEY].HasMember(MSFT_PACKING_INDEX_KEY));
                     }
 
-                    if (!material.normalTexture.id.empty())
+                    if (!material.normalTexture.textureId.empty())
                     {
                         // Check the new extension contains a normal texture
                         Assert::IsTrue(ormJson[MSFT_PACKING_ORM_NORMALTEXTURE_KEY].IsObject());
@@ -106,7 +106,7 @@ namespace Microsoft::glTF::Toolkit::Test
             TestUtils::LoadAndExecuteGLTFTest(c_cubeAsset3DJson, [](auto doc, auto path)
             {
                 auto material = doc.materials.Elements()[0];
-                auto packedDoc = GLTFTexturePackingUtils::PackMaterialForWindowsMR(TestStreamReader(path), doc, material, TexturePacking::OcclusionRoughnessMetallic, "");
+                auto packedDoc = GLTFTexturePackingUtils::PackMaterialForWindowsMR(std::make_shared<TestStreamReader>(path), doc, material, TexturePacking::OcclusionRoughnessMetallic, "");
 
                 // Check that nothing changed
                 Assert::IsTrue(doc == packedDoc);
@@ -119,7 +119,7 @@ namespace Microsoft::glTF::Toolkit::Test
             TestUtils::LoadAndExecuteGLTFTest(c_waterBottleJson, [](auto doc, auto path)
             {
                 auto material = doc.materials.Elements()[0];
-                auto packedDoc = GLTFTexturePackingUtils::PackMaterialForWindowsMR(TestStreamReader(path), doc, material, TexturePacking::None, "");
+                auto packedDoc = GLTFTexturePackingUtils::PackMaterialForWindowsMR(std::make_shared<TestStreamReader>(path), doc, material, TexturePacking::None, "");
 
                 // Check that nothing changed
                 Assert::IsTrue(doc == packedDoc);
@@ -163,7 +163,7 @@ namespace Microsoft::glTF::Toolkit::Test
             // This asset has no materials
             TestUtils::LoadAndExecuteGLTFTest(c_cubeAsset3DJson, [](auto doc, auto path)
             {
-                auto packedDoc = GLTFTexturePackingUtils::PackAllMaterialsForWindowsMR(TestStreamReader(path), doc, TexturePacking::OcclusionRoughnessMetallic, "");
+                auto packedDoc = GLTFTexturePackingUtils::PackAllMaterialsForWindowsMR(std::make_shared<TestStreamReader>(path), doc, TexturePacking::OcclusionRoughnessMetallic, "");
 
                 // Check that nothing changed
                 Assert::IsTrue(doc == packedDoc);
@@ -175,7 +175,7 @@ namespace Microsoft::glTF::Toolkit::Test
             // This asset has all textures
             TestUtils::LoadAndExecuteGLTFTest(c_waterBottleJson, [](auto doc, auto path)
             {
-                auto packedDoc = GLTFTexturePackingUtils::PackAllMaterialsForWindowsMR(TestStreamReader(path), doc, TexturePacking::None, "");
+                auto packedDoc = GLTFTexturePackingUtils::PackAllMaterialsForWindowsMR(std::make_shared<TestStreamReader>(path), doc, TexturePacking::None, "");
 
                 // Check that nothing changed
                 Assert::IsTrue(doc == packedDoc);
@@ -184,18 +184,18 @@ namespace Microsoft::glTF::Toolkit::Test
 
         TEST_METHOD(GLTFTexturePackingUtils_PackAllWithOneMaterial)
         {
-            std::unique_ptr<GLTFDocument> documentPackedSingleTexture;
-            std::unique_ptr<GLTFDocument> documentPackedAllTextures;
+            std::unique_ptr<Document> documentPackedSingleTexture;
+            std::unique_ptr<Document> documentPackedAllTextures;
 
             // This asset has all textures
             TestUtils::LoadAndExecuteGLTFTest(c_waterBottleJson, [&documentPackedSingleTexture](auto doc, auto path)
             {
-                documentPackedSingleTexture = std::make_unique<GLTFDocument>(GLTFTexturePackingUtils::PackMaterialForWindowsMR(TestStreamReader(path), doc, doc.materials.Elements()[0], TexturePacking::OcclusionRoughnessMetallic, ""));
+                documentPackedSingleTexture = std::make_unique<Document>(GLTFTexturePackingUtils::PackMaterialForWindowsMR(std::make_shared<TestStreamReader>(path), doc, doc.materials.Elements()[0], TexturePacking::OcclusionRoughnessMetallic, ""));
             });
 
             TestUtils::LoadAndExecuteGLTFTest(c_waterBottleJson, [&documentPackedAllTextures](auto doc, auto path)
             {
-                documentPackedAllTextures = std::make_unique<GLTFDocument>(GLTFTexturePackingUtils::PackAllMaterialsForWindowsMR(TestStreamReader(path), doc, TexturePacking::OcclusionRoughnessMetallic, ""));
+                documentPackedAllTextures = std::make_unique<Document>(GLTFTexturePackingUtils::PackAllMaterialsForWindowsMR(std::make_shared<TestStreamReader>(path), doc, TexturePacking::OcclusionRoughnessMetallic, ""));
             });
 
             // Assert there's one material

--- a/glTF-Toolkit.Test/Helpers/TestUtils.h
+++ b/glTF-Toolkit.Test/Helpers/TestUtils.h
@@ -7,7 +7,7 @@
 
 #include <memory>
 #include "GLTFSDK/IStreamWriter.h"
-#include "GLTFSDK/GLTFConstants.h"
+#include "GLTFSDK/Constants.h"
 #include "GLTFSDK/Serialize.h"
 #include "GLTFSDK/Deserialize.h"
 
@@ -114,7 +114,7 @@ namespace Microsoft::glTF::Toolkit::Test
             return tempStream;
         }
 
-        typedef std::function<void(const GLTFDocument& doc, const std::string& gltfAbsolutePath)> GLTFAction;
+        typedef std::function<void(const Document& doc, const std::string& gltfAbsolutePath)> GLTFAction;
 
         static void LoadAndExecuteGLTFTest(const char * gltfRelativePath, GLTFAction action)
         {
@@ -125,7 +125,7 @@ namespace Microsoft::glTF::Toolkit::Test
             {
                 // Deserialize input json
                 auto inputJson = std::string(std::istreambuf_iterator<char>(*input), std::istreambuf_iterator<char>());
-                auto doc = DeserializeJson(inputJson);
+                auto doc = Deserialize(inputJson);
 
                 action(doc, absolutePath);
             }

--- a/glTF-Toolkit.Test/Resources/gltf/CubeAsset3D.gltf
+++ b/glTF-Toolkit.Test/Resources/gltf/CubeAsset3D.gltf
@@ -120,5 +120,5 @@
 		}
 	],
 	"scene": 0,
-	"extensionsUsed": ["KHR_materials_PBRSpecularGlossiness"]
+	"extensionsUsed": ["KHR_materials_pbrSpecularGlossiness"]
 }

--- a/glTF-Toolkit.Test/Resources/gltf/CubeWithLOD.gltf
+++ b/glTF-Toolkit.Test/Resources/gltf/CubeWithLOD.gltf
@@ -97,5 +97,5 @@
 		}
 	],
 	"scene": 0,
-	"extensionsUsed": ["KHR_materials_PBRSpecularGlossiness"]
+	"extensionsUsed": ["KHR_materials_pbrSpecularGlossiness", "MSFT_lod"]
 }

--- a/glTF-Toolkit.Test/glTF-Toolkit.Test.vcxproj
+++ b/glTF-Toolkit.Test/glTF-Toolkit.Test.vcxproj
@@ -237,15 +237,15 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\rapidjson.temprelease.0.0.2.20\build\native\rapidjson.temprelease.targets" Condition="Exists('..\packages\rapidjson.temprelease.0.0.2.20\build\native\rapidjson.temprelease.targets')" />
-    <Import Project="..\packages\directxtex_desktop_2015.2018.2.9.1\build\native\directxtex_desktop_2015.targets" Condition="Exists('..\packages\directxtex_desktop_2015.2018.2.9.1\build\native\directxtex_desktop_2015.targets')" />
-    <Import Project="..\packages\Microsoft.glTF.CPP.1.3.46.0\build\native\Microsoft.glTF.CPP.targets" Condition="Exists('..\packages\Microsoft.glTF.CPP.1.3.46.0\build\native\Microsoft.glTF.CPP.targets')" />
+    <Import Project="..\packages\directxtex_desktop_2015.2018.6.1.2\build\native\directxtex_desktop_2015.targets" Condition="Exists('..\packages\directxtex_desktop_2015.2018.6.1.2\build\native\directxtex_desktop_2015.targets')" />
+    <Import Project="..\packages\Microsoft.glTF.CPP.1.5.19.0\build\native\Microsoft.glTF.CPP.targets" Condition="Exists('..\packages\Microsoft.glTF.CPP.1.5.19.0\build\native\Microsoft.glTF.CPP.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\rapidjson.temprelease.0.0.2.20\build\native\rapidjson.temprelease.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\rapidjson.temprelease.0.0.2.20\build\native\rapidjson.temprelease.targets'))" />
-    <Error Condition="!Exists('..\packages\directxtex_desktop_2015.2018.2.9.1\build\native\directxtex_desktop_2015.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\directxtex_desktop_2015.2018.2.9.1\build\native\directxtex_desktop_2015.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.glTF.CPP.1.3.46.0\build\native\Microsoft.glTF.CPP.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.glTF.CPP.1.3.46.0\build\native\Microsoft.glTF.CPP.targets'))" />
+    <Error Condition="!Exists('..\packages\directxtex_desktop_2015.2018.6.1.2\build\native\directxtex_desktop_2015.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\directxtex_desktop_2015.2018.6.1.2\build\native\directxtex_desktop_2015.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.glTF.CPP.1.5.19.0\build\native\Microsoft.glTF.CPP.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.glTF.CPP.1.5.19.0\build\native\Microsoft.glTF.CPP.targets'))" />
   </Target>
 </Project>

--- a/glTF-Toolkit.Test/packages.config
+++ b/glTF-Toolkit.Test/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="directxtex_desktop_2015" version="2018.2.9.1" targetFramework="native" />
-  <package id="Microsoft.glTF.CPP" version="1.3.46.0" targetFramework="native" />
+  <package id="directxtex_desktop_2015" version="2018.6.1.2" targetFramework="native" />
+  <package id="Microsoft.glTF.CPP" version="1.5.19.0" targetFramework="native" />
   <package id="rapidjson.temprelease" version="0.0.2.20" targetFramework="native" />
 </packages>

--- a/glTF-Toolkit.UWP.Test/UWPTest.cs
+++ b/glTF-Toolkit.UWP.Test/UWPTest.cs
@@ -49,19 +49,19 @@ namespace Microsoft.glTF.Toolkit.UWP.Test
             // compare one of the extracted images to the source images
             StorageFile sourceImageFile = await StorageFile.GetFileFromApplicationUriAsync(new Uri("ms-appx:///Assets/3DModels/WaterBottle_diffuse.png"));
             StorageFile outputImageFile = await outputFolder.GetFileAsync(glbBaseName + "_image5.png");
-            Assert.IsTrue(await CompareFilesAsync(sourceImageFile, outputImageFile));
+            Assert.IsTrue(await CompareFilesAsync(sourceImageFile, outputImageFile), "images");
 
             // compare the extracted model (.bin) to the source model (.bin) file
             StorageFile sourceBinFile = await StorageFile.GetFileFromApplicationUriAsync(new Uri("ms-appx:///Assets/3DModels/" + glbBaseName + ".bin"));
             StorageFile outputBinFile = await outputFolder.GetFileAsync(glbBaseName + ".bin");
-            Assert.IsTrue(await CompareFilesAsync(sourceBinFile, outputBinFile));
+            Assert.IsTrue(await CompareFilesAsync(sourceBinFile, outputBinFile), "bins");
 
             // Pack the gltf back into a glb file
             StorageFile gltfFile = await outputFolder.GetFileAsync(glbBaseName + ".gltf");
             StorageFile outputGlbFile = await GLTFSerialization.PackGLTFAsync(gltfFile, outputFolder, glbFileName);
 
             // compare the new glb to the old glb
-            Assert.IsTrue(await CompareFilesAsync(sourceGlbFile, outputGlbFile));
+            Assert.IsTrue(await CompareFilesAsync(sourceGlbFile, outputGlbFile), "glb");
         }
 
         [TestMethod]

--- a/glTF-Toolkit.UWP.Test/glTF-Toolkit.UWP.Test.csproj
+++ b/glTF-Toolkit.UWP.Test/glTF-Toolkit.UWP.Test.csproj
@@ -131,13 +131,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.0.7</Version>
+      <Version>6.2.0-Preview1-26502-02</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestAdapter">
-      <Version>1.2.0</Version>
+      <Version>1.3.2</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestFramework">
-      <Version>1.2.0</Version>
+      <Version>1.3.2</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup Condition="'$(Platform)'=='x86'">

--- a/glTF-Toolkit.UWP/GLTFSerialization.cpp
+++ b/glTF-Toolkit.UWP/GLTFSerialization.cpp
@@ -8,7 +8,7 @@
 #include <GLBtoGLTF.h>
 #include <SerializeBinary.h>
 
-#include <GLTFSDK/GLTFDocument.h>
+#include <GLTFSDK/Document.h>
 
 using namespace Concurrency;
 using namespace Microsoft::glTF;
@@ -50,18 +50,18 @@ IAsyncOperation<StorageFile^>^ GLTFSerialization::PackGLTFAsync(StorageFile^ sou
 
         return create_task([stream]()
         {
-            return std::make_shared<GLTFDocument>(DeserializeJson(*stream));
+            return std::make_shared<Document>(Deserialize(*stream));
         })
-        .then([sourceGltf, outputFolder, glbName](std::shared_ptr<GLTFDocument> document)
+        .then([sourceGltf, outputFolder, glbName](std::shared_ptr<Document> document)
         {
             return create_task(sourceGltf->GetParentAsync())
             .then([outputFolder, glbName, document](StorageFolder^ gltfFolder)
             { 
-                GLTFStreamReader streamReader(gltfFolder);
+                auto streamReader = std::make_shared<GLTFStreamReader>(gltfFolder);
 
                 String^ outputGlbPath = outputFolder->Path + "\\" + glbName;
                 std::wstring outputGlbPathW = outputGlbPath->Data();
-                SerializeBinary(*document, streamReader, std::make_unique<GLBStreamFactory>(outputGlbPathW));
+                SerializeBinary(*document, streamReader, std::make_shared<GLBStreamWriter>(outputGlbPathW));
 
                 return outputFolder->GetFileAsync(glbName);
             });

--- a/glTF-Toolkit.UWP/GLTFStreams.h
+++ b/glTF-Toolkit.UWP/GLTFStreams.h
@@ -5,7 +5,7 @@
 
 #include <filesystem>
 #include <GLTFSDK/IStreamReader.h>
-#include <GLTFSDK/IStreamFactory.h>
+#include <GLTFSDK/IStreamWriter.h>
 
 namespace Microsoft::glTF::Toolkit::UWP
 {
@@ -36,30 +36,19 @@ namespace Microsoft::glTF::Toolkit::UWP
         std::experimental::filesystem::path m_uriBase;
     };
 
-    class GLBStreamFactory : public Microsoft::glTF::IStreamFactory
+    class GLBStreamWriter : public Microsoft::glTF::IStreamWriter
     {
     public:
-        GLBStreamFactory(const std::wstring& filename) :
-            m_stream(std::make_shared<std::ofstream>(filename, std::ios_base::binary | std::ios_base::out)),
-            m_tempStream(std::make_shared<std::stringstream>(std::ios_base::binary | std::ios_base::in | std::ios_base::out))
+        GLBStreamWriter(const std::wstring& filename) :
+            m_stream(std::make_shared<std::ofstream>(filename, std::ios_base::binary | std::ios_base::out))
         { }
-
-        std::shared_ptr<std::istream> GetInputStream(const std::string&) const override
-        {
-            throw std::logic_error("Not implemented");
-        }
 
         std::shared_ptr<std::ostream> GetOutputStream(const std::string&) const override
         {
             return m_stream;
         }
 
-        std::shared_ptr<std::iostream> GetTemporaryStream(const std::string&) const override
-        {
-            return m_tempStream;
-        }
     private:
         std::shared_ptr<std::ofstream> m_stream;
-        std::shared_ptr<std::stringstream> m_tempStream;
     };
 }

--- a/glTF-Toolkit.UWP/glTF-Toolkit.UWP.vcxproj
+++ b/glTF-Toolkit.UWP/glTF-Toolkit.UWP.vcxproj
@@ -284,15 +284,15 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\rapidjson.temprelease.0.0.2.20\build\native\rapidjson.temprelease.targets" Condition="Exists('..\packages\rapidjson.temprelease.0.0.2.20\build\native\rapidjson.temprelease.targets')" />
-    <Import Project="..\packages\directxtex_uwp.2018.2.9.1\build\native\directxtex_uwp.targets" Condition="Exists('..\packages\directxtex_uwp.2018.2.9.1\build\native\directxtex_uwp.targets')" />
-    <Import Project="..\packages\Microsoft.glTF.CPP.1.3.46.0\build\native\Microsoft.glTF.CPP.targets" Condition="Exists('..\packages\Microsoft.glTF.CPP.1.3.46.0\build\native\Microsoft.glTF.CPP.targets')" />
+    <Import Project="..\packages\directxtex_uwp.2018.6.1.2\build\native\directxtex_uwp.targets" Condition="Exists('..\packages\directxtex_uwp.2018.6.1.2\build\native\directxtex_uwp.targets')" />
+    <Import Project="..\packages\Microsoft.glTF.CPP.1.5.19.0\build\native\Microsoft.glTF.CPP.targets" Condition="Exists('..\packages\Microsoft.glTF.CPP.1.5.19.0\build\native\Microsoft.glTF.CPP.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\rapidjson.temprelease.0.0.2.20\build\native\rapidjson.temprelease.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\rapidjson.temprelease.0.0.2.20\build\native\rapidjson.temprelease.targets'))" />
-    <Error Condition="!Exists('..\packages\directxtex_uwp.2018.2.9.1\build\native\directxtex_uwp.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\directxtex_uwp.2018.2.9.1\build\native\directxtex_uwp.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.glTF.CPP.1.3.46.0\build\native\Microsoft.glTF.CPP.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.glTF.CPP.1.3.46.0\build\native\Microsoft.glTF.CPP.targets'))" />
+    <Error Condition="!Exists('..\packages\directxtex_uwp.2018.6.1.2\build\native\directxtex_uwp.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\directxtex_uwp.2018.6.1.2\build\native\directxtex_uwp.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.glTF.CPP.1.5.19.0\build\native\Microsoft.glTF.CPP.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.glTF.CPP.1.5.19.0\build\native\Microsoft.glTF.CPP.targets'))" />
   </Target>
 </Project>

--- a/glTF-Toolkit.UWP/packages.config
+++ b/glTF-Toolkit.UWP/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="directxtex_uwp" version="2018.2.9.1" targetFramework="native" />
-  <package id="Microsoft.glTF.CPP" version="1.3.46.0" targetFramework="native" />
+  <package id="directxtex_uwp" version="2018.6.1.2" targetFramework="native" />
+  <package id="Microsoft.glTF.CPP" version="1.5.19.0" targetFramework="native" />
   <package id="rapidjson.temprelease" version="0.0.2.20" targetFramework="native" />
 </packages>

--- a/glTF-Toolkit/GLTFMeshCompressionUtils.cpp
+++ b/glTF-Toolkit/GLTFMeshCompressionUtils.cpp
@@ -1,0 +1,264 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"
+#include "AccessorUtils.h"
+
+#include "GLTFMeshCompressionUtils.h"
+#include "GLTFSDK/MeshPrimitiveUtils.h"
+#include "GLTFSDK/ExtensionsKHR.h"
+#include "GLTFSDK/BufferBuilder.h"
+
+#pragma warning(push)
+#pragma warning(disable: 4081)
+#pragma warning(disable: 4244)
+#pragma warning(disable: 4018)
+#pragma warning(disable: 4389)
+#include "draco/compression/encode.h"
+#include "draco/core/cycle_timer.h"
+#include "draco/io/mesh_io.h"
+#include "draco/io/point_cloud_io.h"
+#pragma warning(pop)
+
+// Usings for glTF
+using namespace Microsoft::glTF;
+using namespace Microsoft::glTF::Toolkit;
+
+class FilepathStreamWriter : public IStreamWriter
+{
+public:
+    FilepathStreamWriter(std::string uriBase) : m_uriBase(uriBase.begin(), uriBase.end()) {}
+
+    virtual ~FilepathStreamWriter() override {}
+    virtual std::shared_ptr<std::ostream> GetOutputStream(const std::string& filename) const override
+    {
+        std::wstring filenameW = std::wstring(filename.begin(), filename.end());
+
+        wchar_t uriAbsoluteRaw[MAX_PATH];
+        // Note: PathCchCombine will return the last argument if it's an absolute path
+        if (FAILED(::PathCchCombine(uriAbsoluteRaw, ARRAYSIZE(uriAbsoluteRaw), m_uriBase.c_str(), filenameW.c_str())))
+        {
+            throw std::invalid_argument("Could not get the base path for the GLTF resources. Try specifying the full path.");
+        }
+
+        return std::make_shared<std::ofstream>(uriAbsoluteRaw, std::ios::binary);
+    }
+private:
+    const std::wstring m_uriBase;
+};
+
+draco::GeometryAttribute::Type GetTypeFromAttributeName(const std::string& name)
+{
+    if (name == ACCESSOR_POSITION)
+    {
+        return draco::GeometryAttribute::Type::POSITION;
+    }
+    if (name == ACCESSOR_NORMAL)
+    {
+        return draco::GeometryAttribute::Type::NORMAL;
+    }
+    if (name == ACCESSOR_TEXCOORD_0)
+    {
+        return draco::GeometryAttribute::Type::TEX_COORD;
+    }
+    if (name == ACCESSOR_TEXCOORD_1)
+    {
+        return draco::GeometryAttribute::Type::TEX_COORD;
+    }
+    if (name == ACCESSOR_COLOR_0)
+    {
+        return draco::GeometryAttribute::Type::COLOR;
+    }
+    if (name == ACCESSOR_JOINTS_0)
+    {
+        return draco::GeometryAttribute::Type::GENERIC;
+    }
+    if (name == ACCESSOR_WEIGHTS_0)
+    {
+        return draco::GeometryAttribute::Type::GENERIC;
+    }
+    return draco::GeometryAttribute::Type::INVALID;
+}
+
+draco::DataType GetDataType(const Accessor& accessor)
+{
+    switch (accessor.componentType)
+    {
+    case COMPONENT_BYTE: return draco::DataType::DT_INT8;
+    case COMPONENT_UNSIGNED_BYTE: return draco::DataType::DT_UINT8;
+    case COMPONENT_SHORT: return draco::DataType::DT_INT16;
+    case COMPONENT_UNSIGNED_SHORT: return draco::DataType::DT_UINT16;
+    case COMPONENT_UNSIGNED_INT: return draco::DataType::DT_UINT32;
+    case COMPONENT_FLOAT: return draco::DataType::DT_FLOAT32;
+    }
+    return draco::DataType::DT_INVALID;
+}
+
+template<typename T>
+int InitializePointAttribute(draco::Mesh& dracoMesh, const std::string& attributeName, const Document& doc, GLTFResourceReader& reader, Accessor& accessor)
+{
+    auto stride = sizeof(T) * Accessor::GetTypeCount(accessor.type);
+    auto numComponents = Accessor::GetTypeCount(accessor.type);
+    draco::PointAttribute pointAttr;
+    pointAttr.Init(GetTypeFromAttributeName(attributeName), nullptr, numComponents, GetDataType(accessor), accessor.normalized, stride, 0);
+    int attId = dracoMesh.AddAttribute(pointAttr, true, accessor.count);
+    auto attrActual = dracoMesh.attribute(attId);
+
+    std::vector<T> values = reader.ReadBinaryData<T>(doc, accessor);
+
+    if ((accessor.min.empty() || accessor.max.empty()) && !values.empty())
+    {
+        auto minmax = AccessorUtils::CalculateMinMax(accessor, values);
+        accessor.min = minmax.first;
+        accessor.max = minmax.second;
+    }
+
+    for (draco::PointIndex i(0); i < accessor.count; ++i)
+    {
+        attrActual->SetAttributeValue(attrActual->mapped_index(i), &values[i.value() * numComponents]);
+    }
+    if (dracoMesh.num_points() == 0) 
+    {
+        dracoMesh.set_num_points(accessor.count);
+    }
+    else if (dracoMesh.num_points() != accessor.count)
+    {
+        throw GLTFException("Inconsistent points count.");
+    }
+
+    return attId;
+}
+
+void SetEncoderOptions(draco::Encoder& encoder, const CompressionOptions& options)
+{
+    encoder.SetAttributeQuantization(draco::GeometryAttribute::POSITION, options.PositionQuantizationBits);
+    encoder.SetAttributeQuantization(draco::GeometryAttribute::TEX_COORD, options.TexCoordQuantizationBits);
+    encoder.SetAttributeQuantization(draco::GeometryAttribute::NORMAL, options.NormalQuantizationBits);
+    encoder.SetAttributeQuantization(draco::GeometryAttribute::COLOR, options.ColorQuantizationBits);
+    encoder.SetAttributeQuantization(draco::GeometryAttribute::GENERIC, options.GenericQuantizationBits);
+    encoder.SetSpeedOptions(options.Speed, options.Speed);
+    encoder.SetTrackEncodedProperties(true);
+}
+
+Document GLTFMeshCompressionUtils::CompressMesh(std::shared_ptr<IStreamReader> streamReader, const Document & doc, CompressionOptions options, const Mesh & mesh, BufferBuilder* builder)
+{
+    GLTFResourceReader reader(streamReader);
+    Document resultDocument(doc);
+    draco::Encoder encoder;
+    SetEncoderOptions(encoder, options);
+
+    Mesh resultMesh(mesh);
+    resultMesh.primitives.clear();
+    for (const auto& primitive : mesh.primitives)
+    {
+        auto dracoExtension = std::make_unique<KHR::MeshPrimitives::DracoMeshCompression>();
+        draco::Mesh dracoMesh;
+        auto indices = MeshPrimitiveUtils::GetIndices32(doc, reader, primitive);
+        size_t numFaces = indices.size() / 3;
+        dracoMesh.SetNumFaces(numFaces);
+        for (size_t i = 0; i < numFaces; i++)
+        {
+            draco::Mesh::Face face;
+            face[0] = indices[(i * 3) + 0];
+            face[1] = indices[(i * 3) + 1];
+            face[2] = indices[(i * 3) + 2];
+            dracoMesh.SetFace(draco::FaceIndex(i), face);
+        }
+
+        Accessor indiciesAccessor(doc.accessors[primitive.indicesAccessorId]);
+        if (resultDocument.bufferViews.Has(indiciesAccessor.bufferViewId))
+        {
+            resultDocument.bufferViews.Remove(indiciesAccessor.bufferViewId);
+        }
+        indiciesAccessor.bufferViewId = "";
+        indiciesAccessor.byteOffset = 0;
+        resultDocument.accessors.Replace(indiciesAccessor);
+
+        for (const auto& attribute : primitive.attributes)
+        {
+            const auto& accessor = doc.accessors[attribute.second];
+            Accessor attributeAccessor(accessor);
+            int attId;
+            switch (accessor.componentType)
+            {
+            case COMPONENT_BYTE:           attId = InitializePointAttribute<int8_t>(dracoMesh, attribute.first, doc, reader, attributeAccessor); break;
+            case COMPONENT_UNSIGNED_BYTE:  attId = InitializePointAttribute<uint8_t>(dracoMesh, attribute.first, doc, reader, attributeAccessor); break;
+            case COMPONENT_SHORT:          attId = InitializePointAttribute<int16_t>(dracoMesh, attribute.first, doc, reader, attributeAccessor); break;
+            case COMPONENT_UNSIGNED_SHORT: attId = InitializePointAttribute<uint16_t>(dracoMesh, attribute.first, doc, reader, attributeAccessor); break;
+            case COMPONENT_UNSIGNED_INT:   attId = InitializePointAttribute<uint32_t>(dracoMesh, attribute.first, doc, reader, attributeAccessor); break;
+            case COMPONENT_FLOAT:          attId = InitializePointAttribute<float>(dracoMesh, attribute.first, doc, reader, attributeAccessor); break;
+            default: throw GLTFException("Unknown component type.");
+            }
+            
+            if (resultDocument.bufferViews.Has(accessor.bufferViewId))
+            {
+                resultDocument.bufferViews.Remove(accessor.bufferViewId);
+            }
+            attributeAccessor.bufferViewId = "";
+            attributeAccessor.byteOffset = 0;
+            resultDocument.accessors.Replace(attributeAccessor);
+
+            dracoExtension->attributes.emplace(attribute.first, dracoMesh.attribute(attId)->unique_id());
+        }
+        if (primitive.targets.size() > 0)
+        {
+            // Set sequential encoding to preserve order of vertices.
+            encoder.SetEncodingMethod(draco::MESH_SEQUENTIAL_ENCODING);
+        }
+
+        dracoMesh.DeduplicateAttributeValues();
+        dracoMesh.DeduplicatePointIds();
+        draco::EncoderBuffer buffer;
+        const draco::Status status = encoder.EncodeMeshToBuffer(dracoMesh, &buffer);
+        if (!status.ok()) {
+            throw GLTFException(std::string("Failed to encode the mesh: ") + status.error_msg());
+        }
+
+        // We must update the original accessors to the encoding out values.
+        Accessor encodedIndexAccessor(resultDocument.accessors[primitive.indicesAccessorId]);
+        encodedIndexAccessor.count = encoder.num_encoded_faces() * 3;
+        resultDocument.accessors.Replace(encodedIndexAccessor);
+
+        for (const auto& dracoAttribute : dracoExtension->attributes)
+        {
+            auto accessorId = primitive.attributes.at(dracoAttribute.first);
+            Accessor encodedAccessor(resultDocument.accessors[accessorId]);
+            encodedAccessor.count = encoder.num_encoded_points();
+            resultDocument.accessors.Replace(encodedAccessor);
+        }
+
+        // Finally put the encoded data in place.
+        auto bufferView = builder->AddBufferView(buffer.data(), buffer.size());
+        dracoExtension->bufferViewId = bufferView.id;
+        MeshPrimitive resultPrim(primitive);
+        resultPrim.SetExtension(std::move(dracoExtension));
+        resultMesh.primitives.emplace_back(resultPrim);
+    }
+    resultDocument.meshes.Replace(resultMesh);
+
+    return resultDocument;
+}
+
+Document GLTFMeshCompressionUtils::CompressMeshes(std::shared_ptr<IStreamReader> streamReader, const Document & doc, CompressionOptions options, const std::string& outputDirectory)
+{
+    Document resultDocument(doc);
+
+    auto writerStream = std::make_shared<FilepathStreamWriter>(outputDirectory);
+    auto writer = std::make_unique<GLTFResourceWriter>(writerStream);
+    writer->SetUriPrefix(outputDirectory);
+    std::unique_ptr<BufferBuilder> builder = std::make_unique<BufferBuilder>(std::move(writer),
+        [&resultDocument](const BufferBuilder& builder) { return std::to_string(resultDocument.buffers.Size() + builder.GetBufferCount()); },
+        [&resultDocument](const BufferBuilder& builder) { return std::to_string(resultDocument.bufferViews.Size() + builder.GetBufferViewCount()); },
+        [&resultDocument](const BufferBuilder& builder) { return std::to_string(resultDocument.accessors.Size() + builder.GetAccessorCount()); });
+    auto buffer = builder->AddBuffer();
+    for (const auto& mesh : doc.meshes.Elements())
+    {
+        resultDocument = CompressMesh(streamReader, resultDocument, options, mesh, builder.get());
+    }
+
+    builder->Output(resultDocument);
+    resultDocument.extensionsUsed.emplace(KHR::MeshPrimitives::DRACOMESHCOMPRESSION_NAME);
+    resultDocument.extensionsRequired.emplace(KHR::MeshPrimitives::DRACOMESHCOMPRESSION_NAME);
+
+    return resultDocument;
+}

--- a/glTF-Toolkit/glTF-Toolkit.vcxproj
+++ b/glTF-Toolkit/glTF-Toolkit.vcxproj
@@ -141,6 +141,7 @@
     <ClInclude Include="inc\DeviceResources.h" />
     <ClInclude Include="inc\GLBtoGLTF.h" />
     <ClInclude Include="inc\GLTFLODUtils.h" />
+    <ClInclude Include="inc\GLTFMeshCompressionUtils.h" />
     <ClInclude Include="inc\GLTFSDK.h" />
     <ClInclude Include="inc\GLTFTextureCompressionUtils.h" />
     <ClInclude Include="inc\GLTFTextureLoadingUtils.h" />
@@ -149,6 +150,7 @@
     <ClInclude Include="inc\SerializeBinary.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="GLTFMeshCompressionUtils.cpp" />
     <ClCompile Include="src\DeviceResources.cpp" />
     <ClCompile Include="src\GLBtoGLTF.cpp" />
     <ClCompile Include="src\GLTFLODUtils.cpp" />

--- a/glTF-Toolkit/glTF-Toolkit.vcxproj
+++ b/glTF-Toolkit/glTF-Toolkit.vcxproj
@@ -163,15 +163,15 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(SolutionDir)packages\rapidjson.temprelease.0.0.2.20\build\native\rapidjson.temprelease.targets" Condition="Exists('$(SolutionDir)packages\rapidjson.temprelease.0.0.2.20\build\native\rapidjson.temprelease.targets')" />
-    <Import Project="$(SolutionDir)packages\directxtex_desktop_2015.2018.2.9.1\build\native\directxtex_desktop_2015.targets" Condition="Exists('$(SolutionDir)packages\directxtex_desktop_2015.2018.2.9.1\build\native\directxtex_desktop_2015.targets')" />
-    <Import Project="$(SolutionDir)packages\Microsoft.glTF.CPP.1.3.46.0\build\native\Microsoft.glTF.CPP.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.glTF.CPP.1.3.46.0\build\native\Microsoft.glTF.CPP.targets')" />
+    <Import Project="$(SolutionDir)\packages\directxtex_desktop_2015.2018.6.1.2\build\native\directxtex_desktop_2015.targets" Condition="Exists('$(SolutionDir)\packages\directxtex_desktop_2015.2018.6.1.2\build\native\directxtex_desktop_2015.targets')" />
+    <Import Project="$(SolutionDir)\packages\Microsoft.glTF.CPP.1.5.19.0\build\native\Microsoft.glTF.CPP.targets" Condition="Exists('$(SolutionDir)\packages\Microsoft.glTF.CPP.1.5.19.0\build\native\Microsoft.glTF.CPP.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)packages\rapidjson.temprelease.0.0.2.20\build\native\rapidjson.temprelease.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\rapidjson.temprelease.0.0.2.20\build\native\rapidjson.temprelease.targets'))" />
-    <Error Condition="!Exists('$(SolutionDir)packages\directxtex_desktop_2015.2018.2.9.1\build\native\directxtex_desktop_2015.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\directxtex_desktop_2015.2018.2.9.1\build\native\directxtex_desktop_2015.targets'))" />
-    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.glTF.CPP.1.3.46.0\build\native\Microsoft.glTF.CPP.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.glTF.CPP.1.3.46.0\build\native\Microsoft.glTF.CPP.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)\packages\directxtex_desktop_2015.2018.6.1.2\build\native\directxtex_desktop_2015.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\directxtex_desktop_2015.2018.6.1.2\build\native\directxtex_desktop_2015.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.glTF.CPP.1.5.19.0\build\native\Microsoft.glTF.CPP.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.glTF.CPP.1.5.19.0\build\native\Microsoft.glTF.CPP.targets'))" />
   </Target>
 </Project>

--- a/glTF-Toolkit/glTF-Toolkit.vcxproj
+++ b/glTF-Toolkit/glTF-Toolkit.vcxproj
@@ -167,6 +167,7 @@
     <Import Project="$(SolutionDir)packages\rapidjson.temprelease.0.0.2.20\build\native\rapidjson.temprelease.targets" Condition="Exists('$(SolutionDir)packages\rapidjson.temprelease.0.0.2.20\build\native\rapidjson.temprelease.targets')" />
     <Import Project="$(SolutionDir)\packages\directxtex_desktop_2015.2018.6.1.2\build\native\directxtex_desktop_2015.targets" Condition="Exists('$(SolutionDir)\packages\directxtex_desktop_2015.2018.6.1.2\build\native\directxtex_desktop_2015.targets')" />
     <Import Project="$(SolutionDir)\packages\Microsoft.glTF.CPP.1.5.19.0\build\native\Microsoft.glTF.CPP.targets" Condition="Exists('$(SolutionDir)\packages\Microsoft.glTF.CPP.1.5.19.0\build\native\Microsoft.glTF.CPP.targets')" />
+    <Import Project="$(SolutionDir)\packages\draco.CPP.1.3.3.0\build\native\draco.CPP.targets" Condition="Exists('$(SolutionDir)\packages\draco.CPP.1.3.3.0\build\native\draco.CPP.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -175,5 +176,6 @@
     <Error Condition="!Exists('$(SolutionDir)packages\rapidjson.temprelease.0.0.2.20\build\native\rapidjson.temprelease.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\rapidjson.temprelease.0.0.2.20\build\native\rapidjson.temprelease.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)\packages\directxtex_desktop_2015.2018.6.1.2\build\native\directxtex_desktop_2015.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\directxtex_desktop_2015.2018.6.1.2\build\native\directxtex_desktop_2015.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.glTF.CPP.1.5.19.0\build\native\Microsoft.glTF.CPP.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.glTF.CPP.1.5.19.0\build\native\Microsoft.glTF.CPP.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)\packages\draco.CPP.1.3.3.0\build\native\draco.CPP.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\draco.CPP.1.3.3.0\build\native\draco.CPP.targets'))" />
   </Target>
 </Project>

--- a/glTF-Toolkit/glTF-Toolkit.vcxproj.filters
+++ b/glTF-Toolkit/glTF-Toolkit.vcxproj.filters
@@ -42,6 +42,9 @@
     <ClInclude Include="inc\GLTFSDK.h">
       <Filter>inc</Filter>
     </ClInclude>
+    <ClInclude Include="inc\GLTFMeshCompressionUtils.h">
+      <Filter>inc</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\DeviceResources.cpp">
@@ -66,6 +69,9 @@
       <Filter>src</Filter>
     </ClCompile>
     <ClCompile Include="src\GLBtoGLTF.cpp">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="GLTFMeshCompressionUtils.cpp">
       <Filter>src</Filter>
     </ClCompile>
   </ItemGroup>

--- a/glTF-Toolkit/inc/GLBtoGLTF.h
+++ b/glTF-Toolkit/inc/GLBtoGLTF.h
@@ -37,7 +37,7 @@ namespace Microsoft::glTF::Toolkit
         /// <returns>
         /// The binary content of the buffer views as a vector.
         /// </returns>
-        static std::vector<char> SaveBin(std::istream* in, const Microsoft::glTF::GLTFDocument& glbDoc, const size_t bufferOffset, const size_t newBufferlength);
+        static std::vector<char> SaveBin(std::istream* in, const Microsoft::glTF::Document& glbDoc, const size_t bufferOffset, const size_t newBufferlength);
 
         /// <summary>
         /// Loads all images in a glTF-Binary (GLB) asset into a map relating each image identifier to the contents of that image.
@@ -49,7 +49,7 @@ namespace Microsoft::glTF::Toolkit
         /// <returns>
         /// A map relating each image identifier to the contents of that image.
         /// </returns>
-        static std::unordered_map<std::string, std::vector<char>> GetImagesData(std::istream* in, const Microsoft::glTF::GLTFDocument& glbDoc, const std::string& name, const size_t bufferOffset);
+        static std::unordered_map<std::string, std::vector<char>> GetImagesData(std::istream* in, const Microsoft::glTF::Document& glbDoc, const std::string& name, const size_t bufferOffset);
 
         /// <summary>
         /// Creates the glTF manifest that represents a GLB file after unpacking.
@@ -59,6 +59,6 @@ namespace Microsoft::glTF::Toolkit
         /// <returns>
         /// A new glTF manifest that represents the same file, but with images and resources referenced by URI instead of embedded ina GLB buffer.
         /// </returns>
-        static Microsoft::glTF::GLTFDocument CreateGLTFDocument(const Microsoft::glTF::GLTFDocument& glbDoc, const std::string& name);
+        static Microsoft::glTF::Document CreateGLTFDocument(const Microsoft::glTF::Document& glbDoc, const std::string& name);
     };
 }

--- a/glTF-Toolkit/inc/GLTFLODUtils.h
+++ b/glTF-Toolkit/inc/GLTFLODUtils.h
@@ -22,20 +22,20 @@ namespace Microsoft::glTF::Toolkit
         /// </summary>
         /// <returns>A map that relates each node ID to a vector of its levels of detail node IDs.</returns>
         /// <param name="doc">The glTF document containing LODs to be parsed.</param>
-        static LODMap ParseDocumentNodeLODs(const GLTFDocument& doc);
+        static LODMap ParseDocumentNodeLODs(const Document& doc);
 
         /// <summary>
-        /// Inserts each LOD GLTFDocument as a node LOD (at the root level) of the specified primary GLTF asset.
+        /// Inserts each LOD Document as a node LOD (at the root level) of the specified primary GLTF asset.
         /// Note: Animation is not currently supported.
         /// </summary>
         /// <returns>The primary GLTF Document with the inserted LOD node.</returns>
         /// <param name="docs">A vector of glTF documents to merge as LODs. The first element of the vector is assumed to be the primary LOD.</param>
         /// <param name="relativePaths">A vector of relative path prefixes to the non-LOD0 LOD gltf documents. Used for finding resources in those LODs.
         /// If not specified, all resources are assumed to be in the same directory.</param>
-        static GLTFDocument MergeDocumentsAsLODs(const std::vector<GLTFDocument>& docs, const std::vector<std::wstring>& relativePaths = std::vector<std::wstring>(), const bool& sharedMaterials = false);
+        static Document MergeDocumentsAsLODs(const std::vector<Document>& docs, const std::vector<std::wstring>& relativePaths = std::vector<std::wstring>(), const bool& sharedMaterials = false);
 
         /// <summary>
-        /// Inserts each LOD GLTFDocument as a node LOD (at the root level) of the specified primary GLTF asset.
+        /// Inserts each LOD Document as a node LOD (at the root level) of the specified primary GLTF asset.
         /// Note: Animation is not currently supported.
         /// </summary>
         /// <returns>The primary GLTF Document with the inserted LOD node.</returns>
@@ -44,7 +44,7 @@ namespace Microsoft::glTF::Toolkit
         /// vector is larger than the size of <see name="docs" />, lower coverage values will cause the asset to be invisible.</param>
         /// <param name="relativePaths">A vector of relative path prefixes to the non-LOD0 LOD gltf documents. Used for finding resources in those LODs.
         /// If not specified, all resources are assumed to be in the same directory.</param>
-        static GLTFDocument MergeDocumentsAsLODs(const std::vector<GLTFDocument>& docs, const std::vector<double>& screenCoveragePercentages, const std::vector<std::wstring>& relativePaths = std::vector<std::wstring>(), const bool& sharedMaterials = false);
+        static Document MergeDocumentsAsLODs(const std::vector<Document>& docs, const std::vector<double>& screenCoveragePercentages, const std::vector<std::wstring>& relativePaths = std::vector<std::wstring>(), const bool& sharedMaterials = false);
 
         /// <summary>
         /// Determines the highest number of Node LODs for a given glTF asset.
@@ -52,7 +52,7 @@ namespace Microsoft::glTF::Toolkit
         /// <param name="doc">The glTF asset for which to count the max number of node LODs.</param>
         /// <param name="lods">A map containing the parsed node LODs in the document.</param>
         /// <returns>The highest number of Node LODs in the asset.</returns>
-        static uint32_t NumberOfNodeLODLevels(const GLTFDocument& doc, const LODMap& lods);
+        static uint32_t NumberOfNodeLODLevels(const Document& doc, const LODMap& lods);
     };
 }
 

--- a/glTF-Toolkit/inc/GLTFMeshCompressionUtils.h
+++ b/glTF-Toolkit/inc/GLTFMeshCompressionUtils.h
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
+
+#include "GLTFSDK.h"
+#include "GLTFSDK/BufferBuilder.h"
+
+namespace Microsoft::glTF::Toolkit
+{
+    /// <summary>Draco compression options.</summary>
+    struct CompressionOptions
+    {
+        int PositionQuantizationBits = 14;
+        int TexCoordQuantizationBits = 12;
+        int NormalQuantizationBits = 10;
+        int ColorQuantizationBits = 8;
+        int GenericQuantizationBits = 12;
+        int Speed = 3;
+    };
+
+    /// <summary>
+    /// Utilities to compress textures in a glTF asset.
+    /// </summary>
+    class GLTFMeshCompressionUtils
+    {
+    public:
+        /// <summary>
+        /// Applies <see cref="CompressMesh" /> to every material in the document, following the same parameter structure as that function.
+        /// </summary>
+        /// <param name="streamReader">A stream reader that is capable of accessing the resources used in the glTF asset by URI.</param>
+        /// <param name="doc">The document from which the mesh will be loaded.</param>
+        /// <param name="options">The compression options that will be used.</param>
+        /// <param name="outputDirectory">The output directory to which compressed data should be saved.</param>
+        /// <returns>
+        /// A new glTF manifest that uses the KHR_draco_mesh_compression extension to point to the compressed meshes.
+        /// </returns>
+        static Document CompressMeshes(std::shared_ptr<IStreamReader> streamReader, const Document & doc, CompressionOptions options, const std::string& outputDirectory);
+
+        /// <summary>
+        /// Applies Draco mesh compression to the supplied mesh and creates a new set of vertex buffers for all the primitive attributes.
+        /// </summary>
+        /// <param name="streamReader">A stream reader that is capable of accessing the resources used in the glTF asset by URI.</param>
+        /// <param name="doc">The document from which the mesh will be loaded.</param>
+        /// <param name="mesh">The mesh which the mesh will be compressed.</param>
+        /// <param name="options">The compression options that will be used.</param>
+        /// <param name="builder">The output buffer builder that handles bufferId generation for the return document.</param>
+        /// <returns>
+        /// A new glTF manifest that uses the KHR_draco_mesh_compression extension to point to the compressed meshes.
+        /// </returns>
+        static Document CompressMesh(std::shared_ptr<IStreamReader> streamReader, const Document & doc, CompressionOptions options, const Mesh & mesh, BufferBuilder* builder);
+    };
+}

--- a/glTF-Toolkit/inc/GLTFSDK.h
+++ b/glTF-Toolkit/inc/GLTFSDK.h
@@ -7,16 +7,15 @@
 #pragma warning(disable : 4634)
 #pragma warning(disable : 4996)
 
-#include <GLTFSDK/GLTFDocument.h>
+#include <GLTFSDK/Document.h>
 #include <GLTFSDK/Deserialize.h>
 #include <GLTFSDK/Serialize.h>
 #include <GLTFSDK/GLTFResourceWriter.h>
 #include <GLTFSDK/GLBResourceReader.h>
 #include <GLTFSDK/GLTFResourceReader.h>
 #include <GLTFSDK/IStreamReader.h>
-#include <GLTFSDK/IStreamFactory.h>
 #include <GLTFSDK/RapidJsonUtils.h>
 #include <GLTFSDK/GLTF.h>
-#include <GLTFSDK/GLTFConstants.h>
+#include <GLTFSDK/Constants.h>
 
 #pragma warning(pop)

--- a/glTF-Toolkit/inc/GLTFTextureCompressionUtils.h
+++ b/glTF-Toolkit/inc/GLTFTextureCompressionUtils.h
@@ -43,7 +43,7 @@ namespace Microsoft::glTF::Toolkit
         /// <param name="generateMipMaps">If true, also generates mip maps when compressing.</param>
         /// <param name="retainOriginalImage">If true, retains the original image on the resulting glTF. If false, 
         /// replaces that image (making the glTF incompatible with most core glTF 2.0 viewers).</param>
-        /// <returns>Returns a new GLTFDocument that contains a new reference to the compressed dds file added as part 
+        /// <returns>Returns a new Document that contains a new reference to the compressed dds file added as part 
         /// of the MSFT_texture_dds extension.</returns>
         /// <example>
         /// Example Input:
@@ -84,7 +84,7 @@ namespace Microsoft::glTF::Toolkit
         /// </code>
         /// </example>
         /// </summary>
-        static GLTFDocument CompressTextureAsDDS(const IStreamReader& streamReader, const GLTFDocument & doc, const Texture & texture, TextureCompression compression, const std::string& outputDirectory, size_t maxTextureSize = std::numeric_limits<size_t>::max(), bool generateMipMaps = true, bool retainOriginalImage = true);
+        static Document CompressTextureAsDDS(std::shared_ptr<IStreamReader> streamReader, const Document & doc, const Texture & texture, TextureCompression compression, const std::string& outputDirectory, size_t maxTextureSize = std::numeric_limits<size_t>::max(), bool generateMipMaps = true, bool retainOriginalImage = true);
 
         /// <summary>
         /// Applies <see cref="CompressTextureAsDDS" /> to all textures in the document that are accessible via materials according to the 
@@ -97,10 +97,10 @@ namespace Microsoft::glTF::Toolkit
         /// <param name="generateMipMaps">If true, also generates mip maps when compressing.</param>
         /// <param name="retainOriginalImage">If true, retains the original image on the resulting glTF. If false, 
         /// replaces that image (making the glTF incompatible with most core glTF 2.0 viewers).</param>
-        /// <returns>Returns a new GLTFDocument that contains alternate textures for all applicable materials following the requirements of the Windows
+        /// <returns>Returns a new Document that contains alternate textures for all applicable materials following the requirements of the Windows
         /// Mixed Reality home using the MSFT_texture_dds extension.</returns>
         /// </summary>
-        static GLTFDocument CompressAllTexturesForWindowsMR(const IStreamReader& streamReader, const GLTFDocument & doc, const std::string& outputDirectory, size_t maxTextureSize = std::numeric_limits<size_t>::max(), bool retainOriginalImages = true);
+        static Document CompressAllTexturesForWindowsMR(std::shared_ptr<IStreamReader> streamReader, const Document & doc, const std::string& outputDirectory, size_t maxTextureSize = std::numeric_limits<size_t>::max(), bool retainOriginalImages = true);
 
         /// <summary>
         /// Compresses a DirectX::ScratchImage in place using the specified compression.

--- a/glTF-Toolkit/inc/GLTFTextureLoadingUtils.h
+++ b/glTF-Toolkit/inc/GLTFTextureLoadingUtils.h
@@ -19,7 +19,7 @@ namespace Microsoft::glTF::Toolkit
         /// <param name="streamReader">A stream reader that is capable of accessing the resources used in the glTF asset by URI.</param>
         /// <param name="doc">The document from which the texture will be loaded.</param>
         /// <param name="textureId">The identifier of the texture to be loaded.</param>
-        static DirectX::ScratchImage LoadTexture(const IStreamReader& streamReader, const GLTFDocument& doc, const std::string& textureId);
+        static DirectX::ScratchImage LoadTexture(std::shared_ptr<const IStreamReader> streamReader, const Document& doc, const std::string& textureId);
     };
 }
 

--- a/glTF-Toolkit/inc/GLTFTexturePackingUtils.h
+++ b/glTF-Toolkit/inc/GLTFTexturePackingUtils.h
@@ -42,7 +42,7 @@ namespace Microsoft::glTF::Toolkit
         /// <returns>
         /// A new glTF manifest that uses the MSFT_packing_occlusionRoughnessMetallic extension to point to the packed textures.
         /// </returns>
-        static GLTFDocument PackMaterialForWindowsMR(const IStreamReader& streamReader, const GLTFDocument & doc, const Material & material, TexturePacking packing, const std::string& outputDirectory);
+        static Document PackMaterialForWindowsMR(std::shared_ptr<IStreamReader> streamReader, const Document & doc, const Material & material, TexturePacking packing, const std::string& outputDirectory);
 
         /// <summary>
         /// Applies <see cref="PackMaterialForWindowsMR" /> to every material in the document, following the same parameter structure as that function.
@@ -54,7 +54,7 @@ namespace Microsoft::glTF::Toolkit
         /// <returns>
         /// A new glTF manifest that uses the MSFT_packing_occlusionRoughnessMetallic extension to point to the packed textures.
         /// </returns>
-        static GLTFDocument PackAllMaterialsForWindowsMR(const IStreamReader& streamReader, const GLTFDocument & doc, TexturePacking packing, const std::string& outputDirectory);
+        static Document PackAllMaterialsForWindowsMR(std::shared_ptr<IStreamReader> streamReader, const Document & doc, TexturePacking packing, const std::string& outputDirectory);
     };
 }
 

--- a/glTF-Toolkit/inc/SerializeBinary.h
+++ b/glTF-Toolkit/inc/SerializeBinary.h
@@ -20,18 +20,18 @@ namespace Microsoft::glTF::Toolkit
     /// <summary>
     /// Serializes a glTF asset as a glTF binary (GLB) file.
     /// </summary>
-    /// <param name="gltfDocument">The glTF asset manifest to be serialized.</param>
+    /// <param name="Document">The glTF asset manifest to be serialized.</param>
     /// <param name="inputStreamReader">A stream reader that is capable of accessing the resources used in the glTF asset by URI.</param>
     /// <param name="outputStreamFactory">A stream factory that is capable of creating an output stream where the GLB will be saved, and a temporary stream for
     /// use during the serialization process.</param>
-    void SerializeBinary(const GLTFDocument& gltfDocument, const IStreamReader& inputStreamReader, std::unique_ptr<const IStreamFactory>&& outputStreamFactory, const AccessorConversionStrategy& accessorConversion = nullptr);
+    void SerializeBinary(const Document& document, std::shared_ptr<const IStreamReader> inputStreamReader, std::shared_ptr<const IStreamWriter> outputStreamWriter, const AccessorConversionStrategy& accessorConversion = nullptr);
 
     /// <summary>
     /// Serializes a glTF asset as a glTF binary (GLB) file.
     /// </summary>
-    /// <param name="gltfDocument">The glTF asset manifest to be serialized.</param>
+    /// <param name="Document">The glTF asset manifest to be serialized.</param>
     /// <param name="resourceReader">A resource reader that is capable of accessing the resources used in the document.</param>
     /// <param name="outputStreamFactory">A stream factory that is capable of creating an output stream where the GLB will be saved, and a temporary stream for
     /// use during the serialization process.</param>
-    void SerializeBinary(const GLTFDocument& gltfDocument, const GLTFResourceReader& resourceReader, std::unique_ptr<const IStreamFactory>&& outputStreamFactory, const AccessorConversionStrategy& accessorConversion = nullptr);
+    void SerializeBinary(const Document& document, const GLTFResourceReader& resourceReader, std::shared_ptr<const IStreamWriter> outputStreamWriter, const AccessorConversionStrategy& accessorConversion = nullptr);
 }

--- a/glTF-Toolkit/packages.config
+++ b/glTF-Toolkit/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="directxtex_desktop_2015" version="2018.6.1.2" targetFramework="native" />
+  <package id="draco.CPP" version="1.3.3.0" targetFramework="native" />
   <package id="Microsoft.glTF.CPP" version="1.5.19.0" targetFramework="native" />
   <package id="rapidjson.temprelease" version="0.0.2.20" targetFramework="native" />
 </packages>

--- a/glTF-Toolkit/packages.config
+++ b/glTF-Toolkit/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="directxtex_desktop_2015" version="2018.2.9.1" targetFramework="native" />
-  <package id="Microsoft.glTF.CPP" version="1.3.46.0" targetFramework="native" />
+  <package id="directxtex_desktop_2015" version="2018.6.1.2" targetFramework="native" />
+  <package id="Microsoft.glTF.CPP" version="1.5.19.0" targetFramework="native" />
   <package id="rapidjson.temprelease" version="0.0.2.20" targetFramework="native" />
 </packages>

--- a/glTF-Toolkit/src/GLBtoGLTF.cpp
+++ b/glTF-Toolkit/src/GLBtoGLTF.cpp
@@ -41,7 +41,7 @@ namespace
     }
 }
 
-std::vector<char> GLBToGLTF::SaveBin(std::istream* input, const GLTFDocument& glbDoc, const size_t bufferOffset, const size_t newBufferlength)
+std::vector<char> GLBToGLTF::SaveBin(std::istream* input, const Document& glbDoc, const size_t bufferOffset, const size_t newBufferlength)
 {
     if (newBufferlength == 0)
     {
@@ -110,7 +110,7 @@ std::vector<char> GLBToGLTF::SaveBin(std::istream* input, const GLTFDocument& gl
     return result;
 }
 
-std::unordered_map<std::string, std::vector<char>> GLBToGLTF::GetImagesData(std::istream* input, const GLTFDocument& glbDoc, const std::string& name, const size_t bufferOffset)
+std::unordered_map<std::string, std::vector<char>> GLBToGLTF::GetImagesData(std::istream* input, const Document& glbDoc, const std::string& name, const size_t bufferOffset)
 {
     input->seekg(0, std::ios::beg);
     std::unordered_map<std::string, int> imageIDs;
@@ -179,9 +179,9 @@ std::unordered_map<std::string, std::vector<char>> GLBToGLTF::GetImagesData(std:
 
 // Create modified gltf from original by removing image buffer segments and updating
 // images, bufferViews and accessors fields accordingly
-GLTFDocument GLBToGLTF::CreateGLTFDocument(const GLTFDocument& glbDoc, const std::string& name)
+Document GLBToGLTF::CreateGLTFDocument(const Document& glbDoc, const std::string& name)
 {
-    GLTFDocument gltfDoc(glbDoc);
+    Document gltfDoc(glbDoc);
 
     gltfDoc.images.Clear();
     gltfDoc.buffers.Clear();
@@ -291,12 +291,12 @@ void GLBToGLTF::UnpackGLB(const std::string& glbPath, const std::string& outDire
 {
     // read glb file into json
     auto glbStream = std::make_shared<std::ifstream>(glbPath, std::ios::binary);
-    auto streamReader = std::make_unique<StreamMock>();
-    GLBResourceReader reader(*streamReader, glbStream);
+    auto streamReader = std::make_shared<StreamMock>();
+    GLBResourceReader reader(streamReader, glbStream);
 
     // get original json
     auto json = reader.GetJson();
-    auto doc = DeserializeJson(json);
+    auto doc = Deserialize(json);
 
     // create new modified json
     auto gltfDoc = GLBToGLTF::CreateGLTFDocument(doc, gltfName);

--- a/glTF-Toolkit/src/GLTFLODUtils.cpp
+++ b/glTF-Toolkit/src/GLTFLODUtils.cpp
@@ -36,9 +36,9 @@ namespace
     inline void AddIndexOffset(MeshPrimitive& primitive, const char* attributeName, size_t offset)
     {
         // an empty id string indicates that the id is not inuse and therefore should not be updated
-        if (primitive.HasAttribute(attributeName))
+        auto attributeItr = primitive.attributes.find(attributeName);
+        if (attributeItr != primitive.attributes.end())
         {
-            auto attributeItr = primitive.attributes.find(attributeName);
             attributeItr->second = std::to_string(std::stoi(attributeItr->second) + offset);
         }
     }

--- a/glTF-Toolkit/src/GLTFLODUtils.cpp
+++ b/glTF-Toolkit/src/GLTFLODUtils.cpp
@@ -78,7 +78,7 @@ namespace
     }
 
     template <typename T>
-    std::string SerializeExtensionMSFTLod(const T&, const std::vector<std::string>& lods, const Document& Document)
+    std::string SerializeExtensionMSFTLod(const T&, const std::vector<std::string>& lods, const Document& document)
     {
         // Omit MSFT_lod entirely if no LODs are available
         if (lods.empty())
@@ -96,14 +96,14 @@ namespace
         {
             for (const auto& lodId : lods)
             {
-                lodIndices.push_back(ToKnownSizeType(Document.materials.GetIndex(lodId)));
+                lodIndices.push_back(ToKnownSizeType(document.materials.GetIndex(lodId)));
             }
         }
         else if (std::is_same<T, Node>())
         {
             for (const auto& lodId : lods)
             {
-                lodIndices.push_back(ToKnownSizeType(Document.nodes.GetIndex(lodId)));
+                lodIndices.push_back(ToKnownSizeType(document.nodes.GetIndex(lodId)));
             }
         }
         else

--- a/glTF-Toolkit/src/GLTFLODUtils.cpp
+++ b/glTF-Toolkit/src/GLTFLODUtils.cpp
@@ -8,10 +8,10 @@
 #include "GLTFLODUtils.h"
 
 #include "GLTFSDK/GLTF.h"
-#include "GLTFSDK/GLTFConstants.h"
+#include "GLTFSDK/Constants.h"
 #include "GLTFSDK/Deserialize.h"
 #include "GLTFSDK/RapidJsonUtils.h"
-#include "GLTFSDK/Schema.h"
+#include "GLTFSDK/ExtensionsKHR.h"
 
 #include <algorithm>
 #include <iostream>
@@ -31,6 +31,16 @@ namespace
     {
         // an empty id string indicates that the id is not inuse and therefore should not be updated
         id = (id.empty()) ? "" : std::to_string(std::stoi(id) + offset);
+    }
+
+    inline void AddIndexOffset(MeshPrimitive& primitive, const char* attributeName, size_t offset)
+    {
+        // an empty id string indicates that the id is not inuse and therefore should not be updated
+        if (primitive.HasAttribute(attributeName))
+        {
+            auto attributeItr = primitive.attributes.find(attributeName);
+            attributeItr->second = std::to_string(std::stoi(attributeItr->second) + offset);
+        }
     }
 
     inline void AddIndexOffsetPacked(rapidjson::Value& json, const char* textureId, size_t offset)
@@ -68,7 +78,7 @@ namespace
     }
 
     template <typename T>
-    std::string SerializeExtensionMSFTLod(const T&, const std::vector<std::string>& lods, const GLTFDocument& gltfDocument)
+    std::string SerializeExtensionMSFTLod(const T&, const std::vector<std::string>& lods, const Document& Document)
     {
         // Omit MSFT_lod entirely if no LODs are available
         if (lods.empty())
@@ -86,14 +96,14 @@ namespace
         {
             for (const auto& lodId : lods)
             {
-                lodIndices.push_back(ToKnownSizeType(gltfDocument.materials.GetIndex(lodId)));
+                lodIndices.push_back(ToKnownSizeType(Document.materials.GetIndex(lodId)));
             }
         }
         else if (std::is_same<T, Node>())
         {
             for (const auto& lodId : lods)
             {
-                lodIndices.push_back(ToKnownSizeType(gltfDocument.nodes.GetIndex(lodId)));
+                lodIndices.push_back(ToKnownSizeType(Document.nodes.GetIndex(lodId)));
             }
         }
         else
@@ -110,9 +120,9 @@ namespace
         return stringBuffer.GetString();
     }
 
-    GLTFDocument AddGLTFNodeLOD(const GLTFDocument& primary, LODMap& primaryLods, const GLTFDocument& lod, const std::wstring& relativePath = L"", bool sharedMaterials = false)
+    Document AddGLTFNodeLOD(const Document& primary, LODMap& primaryLods, const Document& lod, const std::wstring& relativePath = L"", bool sharedMaterials = false)
     {
-        Microsoft::glTF::GLTFDocument gltfLod(primary);
+        Microsoft::glTF::Document gltfLod(primary);
 
         auto primaryScenes = primary.scenes.Elements();
         auto lodScenes = lod.scenes.Elements();
@@ -274,15 +284,18 @@ namespace
                 material.name += nodeLodLabel;
                 AddIndexOffset(material.id, materialOffset);
 
-                AddIndexOffset(material.normalTexture.id, texturesOffset);
-                AddIndexOffset(material.occlusionTexture.id, texturesOffset);
-                AddIndexOffset(material.emissiveTextureId, texturesOffset);
+                AddIndexOffset(material.normalTexture.textureId, texturesOffset);
+                AddIndexOffset(material.occlusionTexture.textureId, texturesOffset);
+                AddIndexOffset(material.emissiveTexture.textureId, texturesOffset);
 
-                AddIndexOffset(material.metallicRoughness.baseColorTextureId, texturesOffset);
-                AddIndexOffset(material.metallicRoughness.metallicRoughnessTextureId, texturesOffset);
+                AddIndexOffset(material.metallicRoughness.baseColorTexture.textureId, texturesOffset);
+                AddIndexOffset(material.metallicRoughness.metallicRoughnessTexture.textureId, texturesOffset);
 
-                AddIndexOffset(material.specularGlossiness.diffuseTextureId, texturesOffset);
-                AddIndexOffset(material.specularGlossiness.specularGlossinessTextureId, texturesOffset);
+                if (material.HasExtension<KHR::Materials::PBRSpecularGlossiness>())
+                {
+                    AddIndexOffset(material.GetExtension<KHR::Materials::PBRSpecularGlossiness>().diffuseTexture.textureId, texturesOffset);
+                    AddIndexOffset(material.GetExtension<KHR::Materials::PBRSpecularGlossiness>().specularGlossinessTexture.textureId, texturesOffset);
+                }
 
                 // MSFT_packing_occlusionRoughnessMetallic packed textures
                 auto ormExtensionIt = material.extensions.find(EXTENSION_MSFT_PACKING_ORM);
@@ -333,12 +346,13 @@ namespace
 
                 for (auto &primitive : mesh.primitives)
                 {
-                    AddIndexOffset(primitive.positionsAccessorId, accessorOffset);
-                    AddIndexOffset(primitive.normalsAccessorId, accessorOffset);
                     AddIndexOffset(primitive.indicesAccessorId, accessorOffset);
-                    AddIndexOffset(primitive.uv0AccessorId, accessorOffset);
-                    AddIndexOffset(primitive.uv1AccessorId, accessorOffset);
-                    AddIndexOffset(primitive.color0AccessorId, accessorOffset);
+                    AddIndexOffset(primitive, ACCESSOR_POSITION, accessorOffset);
+                    AddIndexOffset(primitive, ACCESSOR_NORMAL, accessorOffset);
+                    
+                    AddIndexOffset(primitive, ACCESSOR_TEXCOORD_0, accessorOffset);
+                    AddIndexOffset(primitive, ACCESSOR_TEXCOORD_1, accessorOffset);
+                    AddIndexOffset(primitive, ACCESSOR_COLOR_0, accessorOffset);
 
                     if (sharedMaterials)
                     {
@@ -360,9 +374,12 @@ namespace
                                            localMaterial.metallicRoughness.baseColorFactor == globalMaterial.metallicRoughness.baseColorFactor &&
                                            localMaterial.metallicRoughness.metallicFactor == globalMaterial.metallicRoughness.metallicFactor &&
                                            localMaterial.occlusionTexture.strength == globalMaterial.occlusionTexture.strength &&
-                                           localMaterial.specularGlossiness.diffuseFactor == globalMaterial.specularGlossiness.diffuseFactor &&
-                                           localMaterial.specularGlossiness.glossinessFactor == globalMaterial.specularGlossiness.glossinessFactor &&
-                                           localMaterial.specularGlossiness.specularFactor == globalMaterial.specularGlossiness.specularFactor;
+                                           localMaterial.HasExtension<KHR::Materials::PBRSpecularGlossiness>() == globalMaterial.HasExtension<KHR::Materials::PBRSpecularGlossiness>() && 
+                                           (!localMaterial.HasExtension<KHR::Materials::PBRSpecularGlossiness>() ||
+                                             (localMaterial.GetExtension<KHR::Materials::PBRSpecularGlossiness>().diffuseFactor == globalMaterial.GetExtension<KHR::Materials::PBRSpecularGlossiness>().diffuseFactor &&
+                                              localMaterial.GetExtension<KHR::Materials::PBRSpecularGlossiness>().glossinessFactor == globalMaterial.GetExtension<KHR::Materials::PBRSpecularGlossiness>().glossinessFactor &&
+                                              localMaterial.GetExtension<KHR::Materials::PBRSpecularGlossiness>().specularFactor == globalMaterial.GetExtension<KHR::Materials::PBRSpecularGlossiness>().specularFactor)
+                                           );
                                 }
                         );
 
@@ -451,10 +468,8 @@ namespace
                     newAnimation.samplers.Append(std::move(newSampler));
                 }
                 
-                size_t channelsOffset = baseAnimation.channels.size();
                 for (auto channel : lodAnimation.channels)
                 {
-                    AddIndexOffset(channel.id, channelsOffset);
                     AddIndexOffset(channel.target.nodeId, nodeOffset);
                     AddIndexOffset(channel.samplerId, samplerOffset);
 
@@ -482,7 +497,7 @@ namespace
     }
 }
 
-LODMap GLTFLODUtils::ParseDocumentNodeLODs(const GLTFDocument& doc)
+LODMap GLTFLODUtils::ParseDocumentNodeLODs(const Document& doc)
 {
     LODMap lodMap;
 
@@ -494,14 +509,14 @@ LODMap GLTFLODUtils::ParseDocumentNodeLODs(const GLTFDocument& doc)
     return lodMap;
 }
 
-GLTFDocument GLTFLODUtils::MergeDocumentsAsLODs(const std::vector<GLTFDocument>& docs, const std::vector<std::wstring>& relativePaths, const bool& sharedMaterials)
+Document GLTFLODUtils::MergeDocumentsAsLODs(const std::vector<Document>& docs, const std::vector<std::wstring>& relativePaths, const bool& sharedMaterials)
 {
     if (docs.empty())
     {
         throw std::invalid_argument("MergeDocumentsAsLODs passed empty vector");
     }
 
-    GLTFDocument gltfPrimary(docs[0]);
+    Document gltfPrimary(docs[0]);
     LODMap lods = ParseDocumentNodeLODs(gltfPrimary);
 
     for (size_t i = 1; i < docs.size(); i++)
@@ -529,9 +544,9 @@ GLTFDocument GLTFLODUtils::MergeDocumentsAsLODs(const std::vector<GLTFDocument>&
     return gltfPrimary;
 }
 
-GLTFDocument GLTFLODUtils::MergeDocumentsAsLODs(const std::vector<GLTFDocument>& docs, const std::vector<double>& screenCoveragePercentages, const std::vector<std::wstring>& relativePaths, const bool& sharedMaterials)
+Document GLTFLODUtils::MergeDocumentsAsLODs(const std::vector<Document>& docs, const std::vector<double>& screenCoveragePercentages, const std::vector<std::wstring>& relativePaths, const bool& sharedMaterials)
 {
-    GLTFDocument merged = MergeDocumentsAsLODs(docs, relativePaths, sharedMaterials);
+    Document merged = MergeDocumentsAsLODs(docs, relativePaths, sharedMaterials);
 
     if (screenCoveragePercentages.size() == 0)
     {
@@ -568,7 +583,7 @@ GLTFDocument GLTFLODUtils::MergeDocumentsAsLODs(const std::vector<GLTFDocument>&
     return merged;
 }
 
-uint32_t GLTFLODUtils::NumberOfNodeLODLevels(const GLTFDocument& doc, const LODMap& lods)
+uint32_t GLTFLODUtils::NumberOfNodeLODLevels(const Document& doc, const LODMap& lods)
 {
     size_t maxLODLevel = 0;
     for (auto node : doc.nodes.Elements())

--- a/glTF-Toolkit/src/GLTFTextureCompressionUtils.cpp
+++ b/glTF-Toolkit/src/GLTFTextureCompressionUtils.cpp
@@ -20,9 +20,9 @@ using namespace Microsoft::glTF::Toolkit;
 
 const char* Microsoft::glTF::Toolkit::EXTENSION_MSFT_TEXTURE_DDS = "MSFT_texture_dds";
 
-GLTFDocument GLTFTextureCompressionUtils::CompressTextureAsDDS(const IStreamReader& streamReader, const GLTFDocument & doc, const Texture & texture, TextureCompression compression, const std::string& outputDirectory, size_t maxTextureSize, bool generateMipMaps, bool retainOriginalImage)
+Document GLTFTextureCompressionUtils::CompressTextureAsDDS(std::shared_ptr<IStreamReader> streamReader, const Document & doc, const Texture & texture, TextureCompression compression, const std::string& outputDirectory, size_t maxTextureSize, bool generateMipMaps, bool retainOriginalImage)
 {
-    GLTFDocument outputDoc(doc);
+    Document outputDoc(doc);
 
     // Early return cases:
     // - No compression requested
@@ -176,9 +176,9 @@ GLTFDocument GLTFTextureCompressionUtils::CompressTextureAsDDS(const IStreamRead
     return outputDoc;
 }
 
-GLTFDocument GLTFTextureCompressionUtils::CompressAllTexturesForWindowsMR(const IStreamReader& streamReader, const GLTFDocument & doc, const std::string& outputDirectory, size_t maxTextureSize, bool retainOriginalImages)
+Document GLTFTextureCompressionUtils::CompressAllTexturesForWindowsMR(std::shared_ptr<IStreamReader> streamReader, const Document & doc, const std::string& outputDirectory, size_t maxTextureSize, bool retainOriginalImages)
 {
-    GLTFDocument outputDoc(doc);
+    Document outputDoc(doc);
 
     for (auto material : doc.materials.Elements())
     {
@@ -191,8 +191,8 @@ GLTFDocument GLTFTextureCompressionUtils::CompressAllTexturesForWindowsMR(const 
         };
 
         // Compress base and emissive texture as BC7
-        compressIfNotEmpty(material.metallicRoughness.baseColorTextureId, TextureCompression::BC7_SRGB);
-        compressIfNotEmpty(material.emissiveTextureId, TextureCompression::BC7_SRGB);
+        compressIfNotEmpty(material.metallicRoughness.baseColorTexture.textureId, TextureCompression::BC7_SRGB);
+        compressIfNotEmpty(material.emissiveTexture.textureId, TextureCompression::BC7_SRGB);
 
         // Get textures from the MSFT_packing_occlusionRoughnessMetallic extension
         if (material.extensions.find(EXTENSION_MSFT_PACKING_ORM) != material.extensions.end())

--- a/glTF-Toolkit/src/GLTFTextureLoadingUtils.cpp
+++ b/glTF-Toolkit/src/GLTFTextureLoadingUtils.cpp
@@ -12,7 +12,7 @@ namespace
 {
 }
 
-DirectX::ScratchImage GLTFTextureLoadingUtils::LoadTexture(const IStreamReader& streamReader, const GLTFDocument& doc, const std::string& textureId)
+DirectX::ScratchImage GLTFTextureLoadingUtils::LoadTexture(std::shared_ptr<const IStreamReader> streamReader, const Document& doc, const std::string& textureId)
 {
     DirectX::ScratchImage output;
 

--- a/glTF-Toolkit/src/GLTFTexturePackingUtils.cpp
+++ b/glTF-Toolkit/src/GLTFTexturePackingUtils.cpp
@@ -60,7 +60,7 @@ namespace
         return std::string(outputImageFullPathStr.begin(), outputImageFullPathStr.end());
     }
 
-    std::string AddImageToDocument(GLTFDocument& doc, const std::string& imageUri)
+    std::string AddImageToDocument(Document& doc, const std::string& imageUri)
     { 
         Image image;
         auto imageId = std::to_string(doc.images.Size());
@@ -71,7 +71,7 @@ namespace
         return imageId;
     }
 
-    void AddTextureToExtension(const std::string& imageId, TexturePacking packing, GLTFDocument& doc, rapidjson::Value& packedExtensionJson, rapidjson::MemoryPoolAllocator<>& a)
+    void AddTextureToExtension(const std::string& imageId, TexturePacking packing, Document& doc, rapidjson::Value& packedExtensionJson, rapidjson::MemoryPoolAllocator<>& a)
     {
         Texture packedTexture;
         auto textureId = std::to_string(doc.textures.Size());
@@ -129,9 +129,9 @@ namespace
     }
 }
 
-GLTFDocument GLTFTexturePackingUtils::PackMaterialForWindowsMR(const IStreamReader& streamReader, const GLTFDocument& doc, const Material& material, TexturePacking packing, const std::string& outputDirectory)
+Document GLTFTexturePackingUtils::PackMaterialForWindowsMR(std::shared_ptr<IStreamReader> streamReader, const Document& doc, const Material& material, TexturePacking packing, const std::string& outputDirectory)
 {
-    GLTFDocument outputDoc(doc);
+    Document outputDoc(doc);
 
     // No packing requested, return copy of document
     if (packing == TexturePacking::None)
@@ -140,9 +140,9 @@ GLTFDocument GLTFTexturePackingUtils::PackMaterialForWindowsMR(const IStreamRead
     }
 
     // Read images from material
-    auto metallicRoughness = material.metallicRoughness.metallicRoughnessTextureId;
-    auto normal = material.normalTexture.id;
-    auto occlusion = material.occlusionTexture.id;
+    auto metallicRoughness = material.metallicRoughness.metallicRoughnessTexture.textureId;
+    auto normal = material.normalTexture.textureId;
+    auto occlusion = material.occlusionTexture.textureId;
 
     bool hasMR = !metallicRoughness.empty();
     bool hasNormal = !normal.empty();
@@ -369,9 +369,9 @@ GLTFDocument GLTFTexturePackingUtils::PackMaterialForWindowsMR(const IStreamRead
     return outputDoc;
 }
 
-GLTFDocument GLTFTexturePackingUtils::PackAllMaterialsForWindowsMR(const IStreamReader& streamReader, const GLTFDocument & doc, TexturePacking packing, const std::string& outputDirectory)
+Document GLTFTexturePackingUtils::PackAllMaterialsForWindowsMR(std::shared_ptr<IStreamReader> streamReader, const Document & doc, TexturePacking packing, const std::string& outputDirectory)
 {
-    GLTFDocument outputDoc(doc);
+    Document outputDoc(doc);
 
     // No packing requested, return copy of document
     if (packing == TexturePacking::None)

--- a/glTF-Toolkit/src/SerializeBinary.cpp
+++ b/glTF-Toolkit/src/SerializeBinary.cpp
@@ -7,9 +7,9 @@
 #include "SerializeBinary.h"
 
 #include "GLTFSDK/GLTF.h"
-#include "GLTFSDK/GLTFDocument.h"
+#include "GLTFSDK/Document.h"
 #include "GLTFSDK/GLBResourceReader.h"
-#include "GLTFSDK/GLBResourceWriter2.h"
+#include "GLTFSDK/GLBResourceWriter.h"
 #include "GLTFSDK/Serialize.h"
 #include "GLTFSDK/BufferBuilder.h"
 
@@ -23,9 +23,9 @@ namespace
         auto extension = uri.substr(uri.rfind('.') + 1, 3);
         std::transform(extension.begin(), extension.end(), extension.begin(), [](char c) { return static_cast<char>(::tolower(static_cast<int>(c))); });
 
-        if (extension == FILE_EXT_DDS)
+        if (extension == "dds")
         {
-            return MIMETYPE_DDS;
+            return "image/vnd-ms.dds";
         }
 
         if (extension == FILE_EXT_JPEG)
@@ -99,7 +99,7 @@ namespace
     }
 
     template <typename T>
-    void SerializeAccessor(const Accessor& accessor, const GLTFDocument& doc, const GLTFResourceReader& reader, BufferBuilder& builder, const AccessorConversionStrategy& accessorConversion)
+    void SerializeAccessor(const Accessor& accessor, const Document& doc, const GLTFResourceReader& reader, BufferBuilder& builder, const AccessorConversionStrategy& accessorConversion)
     {
         builder.AddBufferView(doc.bufferViews.Get(accessor.bufferViewId).target);
         const std::vector<T>& accessorContents = reader.ReadBinaryData<T>(doc, accessor);
@@ -121,7 +121,7 @@ namespace
         }
     }
 
-    void SerializeAccessor(const Accessor& accessor, const GLTFDocument& doc, const GLTFResourceReader& reader, BufferBuilder& builder, const AccessorConversionStrategy& accessorConversion)
+    void SerializeAccessor(const Accessor& accessor, const Document& doc, const GLTFResourceReader& reader, BufferBuilder& builder, const AccessorConversionStrategy& accessorConversion)
     {
         switch (accessor.componentType)
         {
@@ -149,14 +149,14 @@ namespace
     }
 }
 
-void Microsoft::glTF::Toolkit::SerializeBinary(const GLTFDocument& gltfDocument,
+void Microsoft::glTF::Toolkit::SerializeBinary(const Document& document,
                                                const GLTFResourceReader& resourceReader,
-                                               std::unique_ptr<const IStreamFactory>&& outputStreamFactory,
+                                               std::shared_ptr<const IStreamWriter> outputStreamWriter,
                                                const AccessorConversionStrategy& accessorConversion)
 {
-    auto writer = std::make_unique<GLBResourceWriter2>(std::move(outputStreamFactory), std::string());
+    auto writer = std::make_unique<GLBResourceWriter>(std::move(outputStreamWriter));
 
-    GLTFDocument outputDoc(gltfDocument);
+    Document outputDoc(document);
 
     outputDoc.buffers.Clear();
     outputDoc.bufferViews.Clear();
@@ -168,11 +168,11 @@ void Microsoft::glTF::Toolkit::SerializeBinary(const GLTFDocument& gltfDocument,
     builder->AddBuffer(GLB_BUFFER_ID);
 
     // Serialize accessors
-    for (auto accessor : gltfDocument.accessors.Elements())
+    for (auto accessor : document.accessors.Elements())
     {
         if (accessor.count > 0)
         {
-            SerializeAccessor(accessor, gltfDocument, resourceReader, *builder, accessorConversion);
+            SerializeAccessor(accessor, document, resourceReader, *builder, accessorConversion);
         }
     }
 
@@ -181,7 +181,7 @@ void Microsoft::glTF::Toolkit::SerializeBinary(const GLTFDocument& gltfDocument,
     {
         Image newImage(image);
 
-        auto data = resourceReader.ReadBinaryData(gltfDocument, image);
+        auto data = resourceReader.ReadBinaryData(document, image);
 
         auto imageBufferView = builder->AddBufferView(data);
 
@@ -199,7 +199,7 @@ void Microsoft::glTF::Toolkit::SerializeBinary(const GLTFDocument& gltfDocument,
     builder->Output(outputDoc);
 
     // Add extensions and extras to bufferViews, if any
-    for (auto bufferView : gltfDocument.bufferViews.Elements())
+    for (auto bufferView : document.bufferViews.Elements())
     {
         auto fixedBufferView = outputDoc.bufferViews.Get(bufferView.id);
         fixedBufferView.extensions = bufferView.extensions;
@@ -210,16 +210,16 @@ void Microsoft::glTF::Toolkit::SerializeBinary(const GLTFDocument& gltfDocument,
 
     auto manifest = Serialize(outputDoc);
 
-    auto outputWriter = dynamic_cast<GLBResourceWriter2 *>(&builder->GetResourceWriter());
+    auto outputWriter = dynamic_cast<GLBResourceWriter*>(&builder->GetResourceWriter());
     if (outputWriter != nullptr)
     {
         outputWriter->Flush(manifest, std::string());
     }
 }
 
-void Microsoft::glTF::Toolkit::SerializeBinary(const GLTFDocument& gltfDocument, const IStreamReader& inputStreamReader,
-                                               std::unique_ptr<const IStreamFactory>&& outputStreamFactory,
+void Microsoft::glTF::Toolkit::SerializeBinary(const Document& Document, std::shared_ptr<const IStreamReader> inputStreamReader,
+                                               std::shared_ptr<const IStreamWriter> outputStreamWriter,
                                                const AccessorConversionStrategy& accessorConversion)
 {
-    SerializeBinary(gltfDocument, GLTFResourceReader{inputStreamReader}, std::move(outputStreamFactory), accessorConversion);
+    SerializeBinary(Document, GLTFResourceReader{inputStreamReader}, std::move(outputStreamWriter), accessorConversion);
 }

--- a/glTF-Toolkit/src/SerializeBinary.cpp
+++ b/glTF-Toolkit/src/SerializeBinary.cpp
@@ -217,9 +217,9 @@ void Microsoft::glTF::Toolkit::SerializeBinary(const Document& document,
     }
 }
 
-void Microsoft::glTF::Toolkit::SerializeBinary(const Document& Document, std::shared_ptr<const IStreamReader> inputStreamReader,
+void Microsoft::glTF::Toolkit::SerializeBinary(const Document& document, std::shared_ptr<const IStreamReader> inputStreamReader,
                                                std::shared_ptr<const IStreamWriter> outputStreamWriter,
                                                const AccessorConversionStrategy& accessorConversion)
 {
-    SerializeBinary(Document, GLTFResourceReader{inputStreamReader}, std::move(outputStreamWriter), accessorConversion);
+    SerializeBinary(document, GLTFResourceReader{inputStreamReader}, std::move(outputStreamWriter), accessorConversion);
 }


### PR DESCRIPTION
Updates for future 1809 (rs5)
Add ability to apply Draco mesh compression.
Modify SerializeBinary to allow for BufferView's that we don't understand natively.

This change requires a vcpkg installation of draco with a [change ](https://github.com/Microsoft/vcpkg/pull/3784) applied.