### PR TITLE
Add index offsets for JOINTS_0 and WEIGHTS_0 accessors

### DIFF
--- a/glTF-Toolkit/src/GLTFLODUtils.cpp
+++ b/glTF-Toolkit/src/GLTFLODUtils.cpp
@@ -340,6 +340,8 @@ namespace
                     AddIndexOffset(primitive.uv1AccessorId, accessorOffset);
                     AddIndexOffset(primitive.color0AccessorId, accessorOffset);
                     AddIndexOffset(primitive.tangentsAccessorId, accessorOffset);
+                    AddIndexOffset(primitive.joints0AccessorId, accessorOffset);
+                    AddIndexOffset(primitive.weights0AccessorId, accessorOffset);
 
                     if (sharedMaterials)
                     {


### PR DESCRIPTION
Merging skinned lods would otherwise reference the incorrect joint and weight accessors