### PR TITLE
Add offset to channel id

### DIFF
--- a/glTF-Toolkit/src/GLTFLODUtils.cpp
+++ b/glTF-Toolkit/src/GLTFLODUtils.cpp
@@ -470,8 +470,10 @@ namespace
                     newAnimation.samplers.Append(std::move(newSampler));
                 }
                 
+                size_t channelOffset = baseAnimation.channels.Size();
                 for (auto channel : lodAnimation.channels.Elements())
                 {
+                    AddIndexOffset(channel.id, channelOffset);
                     AddIndexOffset(channel.target.nodeId, nodeOffset);
                     AddIndexOffset(channel.samplerId, samplerOffset);
 


### PR DESCRIPTION
I was getting a "key already exists in IndexedContainer" exception when trying to merge animated assets