### PR TITLE
Perform material processing after lod merging to fix share material comparison

### DIFF
--- a/glTF-Toolkit/src/GLTFLODUtils.cpp
+++ b/glTF-Toolkit/src/GLTFLODUtils.cpp
@@ -369,19 +369,13 @@ namespace
                                 [localMaterial](auto globalMaterial) {
                                     // check that the materials are the same, noting that the texture and material ids will differ
                                     return localMaterial.name == globalMaterial.name &&
-                                           localMaterial.alphaMode == globalMaterial.alphaMode &&
-                                           localMaterial.alphaCutoff == globalMaterial.alphaCutoff &&
-                                           localMaterial.emissiveFactor == globalMaterial.emissiveFactor &&
-                                           localMaterial.doubleSided == globalMaterial.doubleSided &&
-                                           localMaterial.metallicRoughness.baseColorFactor == globalMaterial.metallicRoughness.baseColorFactor &&
-                                           localMaterial.metallicRoughness.metallicFactor == globalMaterial.metallicRoughness.metallicFactor &&
-                                           localMaterial.occlusionTexture.strength == globalMaterial.occlusionTexture.strength &&
-                                           localMaterial.HasExtension<KHR::Materials::PBRSpecularGlossiness>() == globalMaterial.HasExtension<KHR::Materials::PBRSpecularGlossiness>() && 
-                                           (!localMaterial.HasExtension<KHR::Materials::PBRSpecularGlossiness>() ||
-                                             (localMaterial.GetExtension<KHR::Materials::PBRSpecularGlossiness>().diffuseFactor == globalMaterial.GetExtension<KHR::Materials::PBRSpecularGlossiness>().diffuseFactor &&
-                                              localMaterial.GetExtension<KHR::Materials::PBRSpecularGlossiness>().glossinessFactor == globalMaterial.GetExtension<KHR::Materials::PBRSpecularGlossiness>().glossinessFactor &&
-                                              localMaterial.GetExtension<KHR::Materials::PBRSpecularGlossiness>().specularFactor == globalMaterial.GetExtension<KHR::Materials::PBRSpecularGlossiness>().specularFactor)
-                                           );
+                                        localMaterial.alphaMode == globalMaterial.alphaMode &&
+                                        localMaterial.alphaCutoff == globalMaterial.alphaCutoff &&
+                                        localMaterial.emissiveFactor == globalMaterial.emissiveFactor &&
+                                        localMaterial.doubleSided == globalMaterial.doubleSided &&
+                                        localMaterial.metallicRoughness.baseColorFactor == globalMaterial.metallicRoughness.baseColorFactor &&
+                                        localMaterial.metallicRoughness.metallicFactor == globalMaterial.metallicRoughness.metallicFactor &&
+                                        localMaterial.occlusionTexture.strength == globalMaterial.occlusionTexture.strength;
                                 }
                         );
 

--- a/glTF-Toolkit/src/GLTFLODUtils.cpp
+++ b/glTF-Toolkit/src/GLTFLODUtils.cpp
@@ -361,21 +361,27 @@ namespace
                         // lower quality LODs can have fewer images and textures than the highest LOD,
                         // so we need to find the correct material index for the same material from the highest LOD
 
-                        auto localMaterial = lod.materials.Get(primitive.materialId);
+                        const Material& localMaterial = lod.materials.Get(primitive.materialId);
 
                         // find merged material index for the given material index in this LOD
                         auto iter = std::find_if(gltfLod.materials.Elements().begin(),
                                 gltfLod.materials.Elements().end(),
-                                [localMaterial](auto globalMaterial) {
+                                [localMaterial](const Material& globalMaterial) {
                                     // check that the materials are the same, noting that the texture and material ids will differ
                                     return localMaterial.name == globalMaterial.name &&
-                                        localMaterial.alphaMode == globalMaterial.alphaMode &&
-                                        localMaterial.alphaCutoff == globalMaterial.alphaCutoff &&
-                                        localMaterial.emissiveFactor == globalMaterial.emissiveFactor &&
-                                        localMaterial.doubleSided == globalMaterial.doubleSided &&
-                                        localMaterial.metallicRoughness.baseColorFactor == globalMaterial.metallicRoughness.baseColorFactor &&
-                                        localMaterial.metallicRoughness.metallicFactor == globalMaterial.metallicRoughness.metallicFactor &&
-                                        localMaterial.occlusionTexture.strength == globalMaterial.occlusionTexture.strength;
+                                           localMaterial.alphaMode == globalMaterial.alphaMode &&
+                                           localMaterial.alphaCutoff == globalMaterial.alphaCutoff &&
+                                           localMaterial.emissiveFactor == globalMaterial.emissiveFactor &&
+                                           localMaterial.doubleSided == globalMaterial.doubleSided &&
+                                           localMaterial.metallicRoughness.baseColorFactor == globalMaterial.metallicRoughness.baseColorFactor &&
+                                           localMaterial.metallicRoughness.metallicFactor == globalMaterial.metallicRoughness.metallicFactor &&
+                                           localMaterial.occlusionTexture.strength == globalMaterial.occlusionTexture.strength &&
+                                           localMaterial.HasExtension<KHR::Materials::PBRSpecularGlossiness>() == globalMaterial.HasExtension<KHR::Materials::PBRSpecularGlossiness>() && 
+                                           (!localMaterial.HasExtension<KHR::Materials::PBRSpecularGlossiness>() ||
+                                             (localMaterial.GetExtension<KHR::Materials::PBRSpecularGlossiness>().diffuseFactor == globalMaterial.GetExtension<KHR::Materials::PBRSpecularGlossiness>().diffuseFactor &&
+                                              localMaterial.GetExtension<KHR::Materials::PBRSpecularGlossiness>().glossinessFactor == globalMaterial.GetExtension<KHR::Materials::PBRSpecularGlossiness>().glossinessFactor &&
+                                              localMaterial.GetExtension<KHR::Materials::PBRSpecularGlossiness>().specularFactor == globalMaterial.GetExtension<KHR::Materials::PBRSpecularGlossiness>().specularFactor)
+                                           );
                                 }
                         );
 


### PR DESCRIPTION
The comparison of materials went bonkers when merging lods with the -share-materials flag when top level materials are converted to metal roughness. This compromise is still far from optimal, but I can't think of a better solution off the top of my head :/